### PR TITLE
Fix store generics

### DIFF
--- a/store/chat/actions.ts
+++ b/store/chat/actions.ts
@@ -154,9 +154,9 @@ export const createChatActions = (
   // メッセージ操作
   sendMessage: async (message, conversationId) => {
     const { messages, activeConversationId } = get()
-    
+
     // 使用する会話IDを決定
-    const targetConversationId = conversationId || activeConversationId || 'default'
+    const targetConversationId: string = conversationId || activeConversationId || 'default'
     
     // 会話の状態を取得
     let conversationState = get().byConversation[targetConversationId]
@@ -551,7 +551,7 @@ export const createChatActions = (
   handleEntryPointQuery: () => {
     // アクティブな会話IDを取得（必ずstring型に）
     const { activeConversationId } = get();
-    const conversationId = activeConversationId || DEFAULT_CONVERSATION_ID;
+    const conversationId: string = activeConversationId || DEFAULT_CONVERSATION_ID;
     
     // OHLCデータを取得
     const { ohlcData } = getChartData() || { ohlcData: [] }

--- a/store/core/immerSet.ts
+++ b/store/core/immerSet.ts
@@ -53,8 +53,7 @@ export const setProperty = <TState, K extends keyof TState>(
   value: TState[K]
 ): MutateDraft<TState> => {
   return (draft) => {
-    // ここでキャストを行い、Draft<TState>のインデックスアクセスを可能にする
-    (draft as unknown as Record<K, TState[K]>)[key] = value
+    (draft as Record<K, TState[K]>)[key] = value
   }
 }
 

--- a/store/rootStore.ts
+++ b/store/rootStore.ts
@@ -20,7 +20,7 @@
 import { create, StateCreator, StoreApi, useStore } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
-import { produce } from 'immer';
+import { produce, type Draft } from 'immer';
 import { devtools } from 'zustand/middleware';
 import { logger as loggerFn } from '@/utils/common'
 import { ChartSlice, createChartSlice } from './chart'
@@ -221,40 +221,28 @@ export const useRootStore = create<RootStore>()(
       persist(
         immer((set, get, api) => {
           // immerSetラッパー - ジェネリックな型パラメータを持つヘルパー関数
-          const immerSet = <TState>(
-            fn: ((state: TState) => void | TState | Partial<TState>) | TState | Partial<TState>
-          ) => {
-            return set((state: RootState) => {
-              // Immerのproduceを使用して不変更新を実行
-              return produce(state, (draft: TState) => {
-                if (typeof fn === 'function') {
-                  const result = (fn as (state: TState) => void | TState | Partial<TState>)(draft);
-                  // 関数がオブジェクトを返した場合はマージ
-                  if (result && typeof result === 'object') {
-                    Object.assign(draft as Record<string, any>, result);
-                  }
-                } else if (fn && typeof fn === 'object') {
-                  // オブジェクトが渡された場合はそのままマージ
-                  Object.assign(draft as Record<string, any>, fn);
-                }
-              });
-            });
+          const immerSet = <TState>(fn: (draft: Draft<TState>) => void) => {
+            return set((state: RootState) =>
+              produce(state, draft => {
+                fn(draft as Draft<TState>);
+              })
+            );
           };
 
           // 型安全なGetState関数
-          const getState = <TState>() => get() as unknown as TState;
+          const getState = <TState>() => get() as TState;
 
           // スライスの作成 - 全て同じパターンを使用
           const dataFetchSlice = createDataFetchSlice(
             (fn) => immerSet<DataFetchSliceState>(fn),
             () => getState<DataFetchSliceState>(),
-            api as unknown as StoreApi<DataFetchSlice>
+            api
           );
           
           const socketSlice = createSocketSlice(
             (fn) => immerSet<SocketSliceState>(fn),
             () => getState<SocketSliceState>(),
-            api as unknown as StoreApi<SocketSlice>
+            api
           );
           
           const symbolSlice = createSymbolSlice(

--- a/store/socket/actions.ts
+++ b/store/socket/actions.ts
@@ -2,10 +2,9 @@
 // 作成: 2025-05-10 - ソケット接続状態を管理するスライスのAction定義
 // 更新: 2025-05-10 - StateCreator型の修正
 
-import { StateCreator } from 'zustand';
+import { type StoreApi, type StateCreator } from 'zustand';
 import { SocketSliceState } from './state';
 import { logger } from '@/utils/common';
-import { type StoreApi } from 'zustand';
 
 export interface SocketSliceActions {
   /**
@@ -37,12 +36,11 @@ export interface SocketSliceActions {
 
 export type SocketSlice = SocketSliceState & SocketSliceActions;
 
-export const createSocketSliceActions: StateCreator<
-  SocketSlice,
-  [],
-  [],
-  SocketSliceActions
-> = (set, get, _store) => ({
+export const createSocketSliceActions = <T extends SocketSliceState>(
+  set: (fn: (state: T) => void) => void,
+  get: () => T,
+  _store: StoreApi<T>
+): SocketSliceActions => ({
   setConnected: (connected: boolean, source: string = 'socket-event') => {
     logger.info(`SocketSlice: 接続状態を${connected}に更新します`, {
       component: 'SocketSlice',

--- a/store/socket/index.ts
+++ b/store/socket/index.ts
@@ -2,10 +2,11 @@
 // SocketSliceのエントリーポイント - 2025-05-13
 // 更新: 2025-05-15 - SocketSlice型をエクスポート追加
 
-import { StoreApi } from 'zustand';
+import { type StoreApi } from 'zustand';
 import { initialSocketState } from './state';
 import { createSocketSliceActions, SocketSlice } from './actions';
 import { logger } from '@/utils/common';
+import type { RootStore } from '../rootStore';
 
 // 型のリエクスポート
 export type { SocketSliceState } from './state';
@@ -18,10 +19,10 @@ export { initializeSocketMonitoring, cleanupSocketMonitoring } from './dispatche
  * SocketSliceを作成する関数
  * rootStoreに統合するためのファクトリ関数
  */
-export const createSocketSlice = <T extends object>(
-  set: StoreApi<T>['setState'],
-  get: StoreApi<T>['getState'],
-  store: StoreApi<T>
+export const createSocketSlice = (
+  set: StoreApi<RootStore>['setState'],
+  get: StoreApi<RootStore>['getState'],
+  store: StoreApi<RootStore>
 ) => {
   // スライスの初期化ログ
   logger.info('SocketSliceを初期化します', {
@@ -32,6 +33,6 @@ export const createSocketSlice = <T extends object>(
   // 状態とアクションを結合して返す
   return {
     ...initialSocketState,
-    ...createSocketSliceActions(set as any, get as any, store as any)
+    ...createSocketSliceActions(set, get, store)
   };
-}; 
+};

--- a/store/symbol/selectors.ts
+++ b/store/symbol/selectors.ts
@@ -19,7 +19,7 @@ import type { SymbolSliceState } from './state';
 /**
  * シンボルスライス全体を取得する基本セレクター
  */
-export const selectSymbolState = (state: RootState): SymbolSliceState => state as unknown as SymbolSliceState;
+export const selectSymbolState = (state: RootState): SymbolSliceState => state as SymbolSliceState;
 
 /**
  * 現在のシンボルを選択するセレクター


### PR DESCRIPTION
## Summary
- clean up generics in socket and root store
- remove unknown casts in selectors and helpers
- annotate conversation IDs for chat actions

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest', 'node')*