### PR TITLE
Add symbol alias fields and supabase re-export

### DIFF
--- a/lib/supabase/index.ts
+++ b/lib/supabase/index.ts
@@ -1,1 +1,1 @@
-export { supabase } from './client';
+export { createClient as supabase } from './client';

--- a/lib/supabase/supabase.ts
+++ b/lib/supabase/supabase.ts
@@ -1,1 +1,1 @@
-export { supabase } from './client';
+export { createClient as supabase } from './client';

--- a/types/symbol/common.ts
+++ b/types/symbol/common.ts
@@ -27,7 +27,17 @@ export interface SymbolInfo {
   id: string;            // 一意のID
   symbol: string;        // 銘柄シンボル（例: "BTC/USDT"）
   baseCoin: string;      // 基軸通貨（例: "BTC"）
+  /**
+   * @deprecated baseCoin を使用してください
+   * レガシー互換のために保持
+   */
+  baseAsset?: string;    // 基軸通貨のエイリアス
   quoteCoin: string;     // 取引通貨（例: "USDT"）
+  /**
+   * @deprecated quoteCoin を使用してください
+   * レガシー互換のために保持
+   */
+  quoteAsset?: string;   // 取引通貨のエイリアス
   minOrderSize: number;  // 最小注文量
   pricePrecision: number; // 価格精度
   quantityPrecision: number; // 数量精度


### PR DESCRIPTION
## Summary
- support legacy baseAsset/quoteAsset fields in SymbolInfo
- expose `createClient` as `supabase` in lib exports for compatibility

## Testing
- `npm test` *(fails: Cannot find type definition file for 'jest')*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'jest')*