### PR TITLE
Add productType selector

### DIFF
--- a/components/symbol/Selector/SymbolSelector.tsx
+++ b/components/symbol/Selector/SymbolSelector.tsx
@@ -21,8 +21,8 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { useRootStore } from '@/store';
 import { 
-  selectCurrentSymbol, 
-  selectExchangeType,
+  selectCurrentSymbol,
+  selectProductType,
   selectFilteredSymbols,
   selectIsLoadingSymbols,
   selectSymbolError,

--- a/hooks/chart/canvas/useChartSectionStores.ts
+++ b/hooks/chart/canvas/useChartSectionStores.ts
@@ -27,7 +27,7 @@ import {
 import { selectChartType } from '@/store/chart/config/selectors';
 import {
   selectCurrentSymbol,
-  selectExchangeType
+  selectProductType
 } from '@/store/barrel';
 
 import type { Timeframe, ChartType } from '@/types/chart';
@@ -46,9 +46,9 @@ import { formatTimestamp } from '@/utils/chart/chartUtils';
 export const useChartSectionStores = () => {
   // SymbolSliceをrootStoreから取得
   const currentSymbol = useRootStore(selectCurrentSymbol);
-  const exchangeType = useRootStore((state) => selectExchangeType(state as any));
+  const exchangeType = useRootStore((state) => selectProductType(state as any));
   const setCurrentSymbol = useRootStore(state => state.setCurrentSymbol);
-  const setExchangeType = useRootStore(state => state.setExchangeType);
+  const setExchangeType = useRootStore(state => state.setProductType ?? state.setExchangeType);
   
   // ChartDataStore (RootStoreから取得)
   const chartData = useRootStore((state) => selectChartData(state as any));

--- a/hooks/chart/canvas/useChartStores.ts
+++ b/hooks/chart/canvas/useChartStores.ts
@@ -20,7 +20,7 @@ import {
   selectChartType, 
   selectOHLCData,
   selectCurrentSymbol,
-  selectExchangeType
+  selectProductType
 } from '@/store/barrel';
 import type { IndicatorType } from '@/types/store/chart';
 import type { DrawingToolType } from '@/types/store/chart';
@@ -36,13 +36,13 @@ export const useChartStores = () => {
   // シンボルストアからデータ取得（rootStoreのSymbolSliceから）
   // リファクタリング中の型エラーを回避するために型アサーションを使用
   const currentSymbol = useRootStore(selectCurrentSymbol as any);
-  const exchangeType = useRootStore(selectExchangeType as any);
+  const exchangeType = useRootStore(selectProductType as any);
   const setCurrentSymbol = useRootStore(state => state.setCurrentSymbol);
   
   // 注: 今後のフェーズでsetProductTypeを追加予定
   
   // 取引種別を設定するメソッド
-  const setExchangeType = useRootStore(state => state.setExchangeType);
+  const setExchangeType = useRootStore(state => state.setProductType ?? state.setExchangeType);
   
   // rootStoreから直接取得 (型不一致を回避するために型アサーションを使用)
   const timeframe = useRootStore(selectTimeframe as any);

--- a/hooks/chart/toolbar/useChartToolbar.ts
+++ b/hooks/chart/toolbar/useChartToolbar.ts
@@ -23,7 +23,7 @@ import {
   selectError 
 } from '@/store/chart/data/selectors';
 import { selectPriceChangePercent } from '@/store/chart/selectors';
-import { selectChartType, selectExchangeType } from '@/store/chart/config/selectors';
+import { selectChartType, selectProductType } from '@/store/chart/config/selectors';
 import { TabType } from '@/types/store/ui';
 import { Timeframe, ChartType } from '@/types/chart';
 import { ExchangeType } from '@/types/constants/enums';
@@ -50,9 +50,9 @@ export function useChartToolbar() {
 
   // チャート設定ストアから状態とアクションを取得（RootStoreから取得するように変更）
   const chartType = useRootStore((state) => selectChartType(state as any));
-  const exchangeType = useRootStore((state) => selectExchangeType(state as any));
+  const exchangeType = useRootStore((state) => selectProductType(state as any));
   const setChartType = useRootStore((state) => state.setChartType);
-  const setExchangeType = useRootStore((state) => state.setExchangeType);
+  const setExchangeType = useRootStore((state) => state.setProductType ?? state.setExchangeType);
 
   // リアルタイム更新の状態とアクションをrootStoreから取得
   const useRealTimeData = useRootStore((state) => state.useRealTimeData);

--- a/hooks/chart/toolbar/useToolbarStores.ts
+++ b/hooks/chart/toolbar/useToolbarStores.ts
@@ -34,9 +34,9 @@ import {
 } from '@/store/chart/data/selectors';
 import { selectActiveTab } from '@/store/ui/selectors';
 // シンボル関連のセレクターをインポート
-import { 
+import {
   selectCurrentSymbol,
-  selectExchangeType
+  selectProductType
 } from '@/store/barrel';
 // インジケーター関連のセレクターをインポート
 import {
@@ -72,9 +72,9 @@ export function useToolbarStores() {
   // SymbolStoreからSymbolSliceに移行
   const currentSymbol = useRootStore(selectCurrentSymbol);
   // 型不一致を解決するためにセレクターをキャスト
-  const exchangeType = useRootStore(selectExchangeType as any);
+  const exchangeType = useRootStore(selectProductType as any);
   const setCurrentSymbol = useRootStore(state => state.setCurrentSymbol);
-  const setExchangeType = useRootStore(state => state.setExchangeType);
+  const setExchangeType = useRootStore(state => state.setProductType ?? state.setExchangeType);
   
   // ChartDataSliceから状態とアクションを取得（RootStoreを使用）
   const chartData = useRootStore(selectChartData);

--- a/hooks/chart/useChartSectionStores.ts
+++ b/hooks/chart/useChartSectionStores.ts
@@ -28,7 +28,7 @@ import {
 import { selectChartType } from '@/store/chart/config/selectors';
 import {
   selectCurrentSymbol,
-  selectExchangeType
+  selectProductType
 } from '@/store/barrel';
 
 import type { Timeframe, ChartType } from '@/types/chart';
@@ -47,9 +47,9 @@ import { formatTimestamp } from '@/utils/chart/chartUtils';
 export const useChartSectionStores = () => {
   // SymbolSliceをrootStoreから取得
   const currentSymbol = useRootStore(selectCurrentSymbol);
-  const exchangeType = useRootStore(selectExchangeType);
+  const exchangeType = useRootStore(selectProductType);
   const setCurrentSymbol = useRootStore(state => state.setCurrentSymbol);
-  const setExchangeType = useRootStore(state => state.setExchangeType);
+  const setExchangeType = useRootStore(state => state.setProductType ?? state.setExchangeType);
   
   // ChartDataStore (RootStoreから取得)
   const chartData = useRootStore(selectChartData);

--- a/hooks/chart/useChartStores.ts
+++ b/hooks/chart/useChartStores.ts
@@ -22,7 +22,7 @@ import {
   selectChartType, 
   selectOHLCData,
   selectCurrentSymbol,
-  selectExchangeType
+  selectProductType
 } from '@/store/barrel';
 import type { IndicatorType } from '@/types/store/chart';
 import type { DrawingToolType } from '@/types/store/chart';
@@ -36,9 +36,9 @@ import type { DrawingToolType } from '@/types/store/chart';
 export const useChartStores = () => {
   // シンボルストアからデータ取得（rootStoreのSymbolSliceから）
   const currentSymbol = useRootStore(selectCurrentSymbol);
-  const exchangeType = useRootStore(selectExchangeType);
+  const exchangeType = useRootStore(selectProductType);
   const setCurrentSymbol = useRootStore(state => state.setCurrentSymbol);
-  const setExchangeType = useRootStore(state => state.setExchangeType);
+  const setExchangeType = useRootStore(state => state.setProductType ?? state.setExchangeType);
   
   // rootStoreから直接取得
   const timeframe = useRootStore(selectTimeframe);

--- a/hooks/chart/useToolbarStores.ts
+++ b/hooks/chart/useToolbarStores.ts
@@ -30,9 +30,9 @@ import {
 } from '@/store/chart/data/selectors';
 import { selectActiveTab } from '@/store/ui/selectors';
 // シンボル関連のセレクターをインポート
-import { 
+import {
   selectCurrentSymbol,
-  selectExchangeType
+  selectProductType
 } from '@/store/barrel';
 // インジケーター関連のセレクターをインポート
 import {
@@ -60,9 +60,9 @@ import { EntrySliceState } from '@/store/entry/state';
 export function useToolbarStores() {
   // SymbolStoreからSymbolSliceに移行
   const currentSymbol = useRootStore(selectCurrentSymbol);
-  const exchangeType = useRootStore(selectExchangeType);
+  const exchangeType = useRootStore(selectProductType);
   const setCurrentSymbol = useRootStore(state => state.setCurrentSymbol);
-  const setExchangeType = useRootStore(state => state.setExchangeType);
+  const setExchangeType = useRootStore(state => state.setProductType ?? state.setExchangeType);
   
   // ChartDataSliceから状態とアクションを取得（RootStoreを使用）
   const chartData = useRootStore(selectChartData);

--- a/store/barrel.ts
+++ b/store/barrel.ts
@@ -77,6 +77,7 @@ export {
 export {
   selectChartType,
   selectExchangeType,
+  selectProductType,
   selectIsCandleChart
 } from "./chart/config/selectors";
 

--- a/store/chart/config/actions.ts
+++ b/store/chart/config/actions.ts
@@ -35,12 +35,23 @@ export const createChartConfigActions = (
   },
 
   // 取引種別（現物/先物など）を設定
-  setExchangeProductType: (exchangeProductType) => {
+  setProductType: (productType) => {
     set((state) => {
-      state.exchangeProductType = exchangeProductType;
+      state.productType = productType;
+      state.exchangeProductType = productType;
     });
 
     // ここでも必要に応じてイベントを発行
-    // 例: eventEmitter.emit("exchangeProductTypeChanged", exchangeProductType);
+    // 例: eventEmitter.emit("productTypeChanged", productType);
+  },
+
+  /**
+   * @deprecated setProductType を使用してください
+   */
+  setExchangeProductType: (exchangeProductType) => {
+    set((state) => {
+      state.productType = exchangeProductType;
+      state.exchangeProductType = exchangeProductType;
+    });
   }
-}); 
+});

--- a/store/chart/config/selectors.ts
+++ b/store/chart/config/selectors.ts
@@ -17,6 +17,11 @@ export const selectChartType = (state: ChartConfigSlice) => state.chartType
 export const selectExchangeType = (state: ChartConfigSlice) => state.exchangeType
 
 /**
+ * 取引種別を選択するセレクター
+ */
+export const selectProductType = (state: ChartConfigSlice) => state.productType
+
+/**
  * キャンドルチャートかどうかを判定するメモ化セレクター
  */
 export const selectIsCandleChart = createSelector(

--- a/store/chart/config/state.ts
+++ b/store/chart/config/state.ts
@@ -19,6 +19,10 @@ export const initialChartConfigState: ChartConfigSliceState = {
   exchangeType: 'bitget' as ExchangeType,
   
   // 取引タイプ
+  productType: 'spot' as ExchangeProductType,
+  /**
+   * @deprecated productType を使用してください
+   */
   exchangeProductType: 'spot' as ExchangeProductType,
   
   // チャートスケール

--- a/store/chart/config/types.ts
+++ b/store/chart/config/types.ts
@@ -16,7 +16,11 @@ export interface ChartConfigSliceState {
   exchangeType: ExchangeType;
   
   // 取引種別（現物、先物など）
-  exchangeProductType: ExchangeProductType;
+  productType: ExchangeProductType;
+  /**
+   * @deprecated productType を使用してください
+   */
+  exchangeProductType?: ExchangeProductType;
   
   // チャートスケール設定
   chartScale?: {
@@ -59,7 +63,11 @@ export interface ChartConfigSliceActions {
   // チャートタイプを設定するアクション
   setChartType: (chartType: ChartType) => void;
   setExchangeType: (exchangeType: ExchangeType) => void;
-  setExchangeProductType: (exchangeProductType: ExchangeProductType) => void;
+  setProductType: (productType: ExchangeProductType) => void;
+  /**
+   * @deprecated setProductType を使用してください
+   */
+  setExchangeProductType?: (exchangeProductType: ExchangeProductType) => void;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add `productType` field to chart config slice
- provide selector and action for product type
- export new selector from barrel file
- update hooks and components to use `selectProductType`

## Testing
- `npm test` *(fails: Cannot find type definition file for 'jest')*