### PR TITLE
Replace setExchangeType usage with setProductType

### DIFF
--- a/__tests__/components/ChartContainer.test.tsx
+++ b/__tests__/components/ChartContainer.test.tsx
@@ -6,7 +6,7 @@
 // 主な機能:
 // - instrumentTypeChangedイベントリスナーのテスト
 // - 先物から現物への切り替え時の銘柄再設定のテスト
-// - setExchangeType関数の呼び出しのテスト
+// - setProductType関数の呼び出しのテスト
 
 import React from 'react';
 import { render, act } from '@testing-library/react';
@@ -70,7 +70,7 @@ describe('ChartContainer', () => {
         currentSymbol: 'BTCUSDT',
         exchangeType: 'futures',
         setCurrentSymbol: mockSetCurrentSymbol,
-        setExchangeType: mockSetExchangeType
+        setProductType: mockSetExchangeType
       };
       
       return selector(state);
@@ -80,7 +80,7 @@ describe('ChartContainer', () => {
     (useSymbolStore as any).getState = jest.fn(() => ({
       currentSymbol: 'BTCUSDT',
       setCurrentSymbol: mockSetCurrentSymbol,
-      setExchangeType: mockSetExchangeType
+      setProductType: mockSetExchangeType
     }));
   });
   
@@ -102,8 +102,8 @@ describe('ChartContainer', () => {
         window.dispatchEvent(event);
       });
       
-      // setExchangeTypeが呼ばれたことを確認
-      expect(useSymbolStore.getState().setExchangeType).toHaveBeenCalledWith('spot');
+      // setProductTypeが呼ばれたことを確認
+      expect(useSymbolStore.getState().setProductType).toHaveBeenCalledWith('spot');
       
       // ログが出力されたことを確認
       expect(logger.info).toHaveBeenCalledWith(
@@ -132,7 +132,7 @@ describe('ChartContainer', () => {
           currentSymbol: 'ETHUSDT',
           exchangeType: 'spot',
           setCurrentSymbol: jest.fn(),
-          setExchangeType: jest.fn()
+          setProductType: jest.fn()
         };
         
         return selector(state);
@@ -154,8 +154,8 @@ describe('ChartContainer', () => {
         window.dispatchEvent(event);
       });
       
-      // setExchangeTypeが呼ばれたことを確認
-      expect(useSymbolStore.getState().setExchangeType).toHaveBeenCalledWith('futures');
+      // setProductTypeが呼ばれたことを確認
+      expect(useSymbolStore.getState().setProductType).toHaveBeenCalledWith('futures');
       
       // ログが出力されたことを確認
       expect(logger.info).toHaveBeenCalledWith(
@@ -190,8 +190,8 @@ describe('ChartContainer', () => {
         });
       }
       
-      // setExchangeTypeが呼ばれたことを確認
-      expect(useSymbolStore.getState().setExchangeType).toHaveBeenCalledWith('spot');
+      // setProductTypeが呼ばれたことを確認
+      expect(useSymbolStore.getState().setProductType).toHaveBeenCalledWith('spot');
     });
   });
 });

--- a/__tests__/integration/data-flow/instrument-type-change-flow.test.ts
+++ b/__tests__/integration/data-flow/instrument-type-change-flow.test.ts
@@ -16,7 +16,7 @@ jest.mock('../../../src/mastra/tools/instrument-type-tools', () => ({
 
 jest.mock('../../../store/socketActions', () => ({
   socketStoreActions: {
-    setExchangeType: jest.fn(),
+    setProductType: jest.fn(),
   },
 }));
 
@@ -93,7 +93,7 @@ const mockedSocketClient = {
     socketEventHandlers['instrument-type-change'] = jest.fn((data) => {
       const { type, symbol = 'BTCUSDT' } = data;
       // 実際にテストしたい処理をモックとして実行
-      socketStoreActions.setExchangeType(type, symbol, 'socket-instrument-type-change');
+      socketStoreActions.setProductType(type, symbol, 'socket-instrument-type-change');
       
       // CustomEventもイベントとして発行
       const event = new CustomEvent('instrumentTypeChanged', { 
@@ -173,7 +173,7 @@ describe('取引タイプ変更フロー', () => {
       });
       
       // 実装に合わせて引数を修正
-      expect(socketStoreActions.setExchangeType).toHaveBeenCalledWith(
+      expect(socketStoreActions.setProductType).toHaveBeenCalledWith(
         'futures',
         'BTCUSDT',
         'socket-instrument-type-change'
@@ -233,7 +233,7 @@ describe('取引タイプ変更フロー', () => {
       });
       
       // 実装に合わせて引数を修正
-      expect(socketStoreActions.setExchangeType).toHaveBeenCalledWith(
+      expect(socketStoreActions.setProductType).toHaveBeenCalledWith(
         'spot',
         'BTCUSDT',
         'socket-instrument-type-change'

--- a/__tests__/integration/data-flow/symbol-change-flow.test.ts
+++ b/__tests__/integration/data-flow/symbol-change-flow.test.ts
@@ -15,7 +15,7 @@ jest.mock('../../../src/mastra/tools/symbol-tools', () => ({
 jest.mock('../../../store/socketActions', () => ({
   socketStoreActions: {
     setSymbol: jest.fn(),
-    setExchangeType: jest.fn(),
+    setProductType: jest.fn(),
   },
 }));
 
@@ -66,7 +66,7 @@ const mockedSocketClient = {
       
       // 実際にテストしたい処理をモックとして実行
       if (exchangeType) {
-        socketStoreActions.setExchangeType(exchangeType, symbol, 'socket-changeSymbol');
+        socketStoreActions.setProductType(exchangeType, symbol, 'socket-changeSymbol');
       }
       
       socketStoreActions.setSymbol(symbol, 'socket-changeSymbol');
@@ -175,7 +175,7 @@ describe('銘柄変更フロー', () => {
         'socket-changeSymbol'
       );
       
-      expect(socketStoreActions.setExchangeType).toHaveBeenCalledWith(
+      expect(socketStoreActions.setProductType).toHaveBeenCalledWith(
         'spot',
         'ETHUSDT',
         'socket-changeSymbol'
@@ -220,7 +220,7 @@ describe('銘柄変更フロー', () => {
       );
       
       // 取引タイプは更新されないことを確認
-      expect(socketStoreActions.setExchangeType).not.toHaveBeenCalled();
+      expect(socketStoreActions.setProductType).not.toHaveBeenCalled();
     }
   });
 

--- a/__tests__/unit/store/socketActions.test.ts
+++ b/__tests__/unit/store/socketActions.test.ts
@@ -14,7 +14,7 @@ jest.mock('../../../store/useSymbolStore', () => ({
   useSymbolStore: {
     getState: jest.fn().mockReturnValue({
       setCurrentSymbol: mockSetCurrentSymbol,
-      setExchangeType: mockSetExchangeType,
+      setProductType: mockSetExchangeType,
       currentSymbol: 'BTCUSDT',
       exchangeType: 'spot',
     }),
@@ -113,12 +113,12 @@ describe('socketStoreActions', () => {
     });
   });
 
-  describe('setExchangeType', () => {
+  describe('setProductType', () => {
     it('正常に取引タイプを更新できること', () => {
       // テスト実行
-      socketActions.setExchangeType('futures', 'BTCUSDT', 'test-source');
+      socketActions.setProductType('futures', 'BTCUSDT', 'test-source');
       
-      // AppStore.setExchangeType が正しく呼ばれたか検証
+      // AppStore.setProductType が正しく呼ばれたか検証
       expect(mockSetExchangeType).toHaveBeenCalledWith(
         'futures'
       );
@@ -136,21 +136,21 @@ describe('socketStoreActions', () => {
     });
 
     it('エラー時に適切にログを出力すること', () => {
-      // setExchangeType でエラーが発生するようにモック
+      // setProductType でエラーが発生するようにモック
       const error = new Error('テストエラー');
       mockSetExchangeType.mockImplementation(() => {
         throw error;
       });
       
       // テスト実行
-      socketActions.setExchangeType('futures', 'BTCUSDT', 'test-source');
+      socketActions.setProductType('futures', 'BTCUSDT', 'test-source');
       
       // エラーログが出力されたか検証
       expect(logger.error).toHaveBeenCalledWith(
         expect.stringContaining('取引タイプ更新エラー'),
         expect.objectContaining({
           component: 'socketActions',
-          action: 'setExchangeType',
+          action: 'setProductType',
           errorMessage: expect.any(String),
           errorStack: expect.any(String),
           type: 'futures',

--- a/__tests__/unit/utils/socketClient.test.ts
+++ b/__tests__/unit/utils/socketClient.test.ts
@@ -19,7 +19,7 @@ jest.mock('../../../store/socketActions', () => ({
   setSocketId: jest.fn(),
   setSymbol: jest.fn(),
   setTimeframe: jest.fn(),
-  setExchangeType: jest.fn(),
+  setProductType: jest.fn(),
 }));
 
 // socket.io-client のモック定義
@@ -286,7 +286,7 @@ describe('socketClient', () => {
         // timestamp: expect.any(Number)
       });
       expect(logger.info).toHaveBeenCalledWith('取引タイプ変更イベント受信:', expectedLog);
-      expect(socketActions.setExchangeType).toHaveBeenCalledWith(eventData.type, expect.any(String), expect.any(String));
+      expect(socketActions.setProductType).toHaveBeenCalledWith(eventData.type, expect.any(String), expect.any(String));
       expect(localStorageMock.setItem).toHaveBeenCalledWith('lastUsedExchangeType', eventData.type);
       expect(localStorageMock.setItem).toHaveBeenCalledWith('selectedInstrumentType', eventData.type);
       expect(dispatchEventSpy).toHaveBeenCalledWith(expect.any(CustomEvent));

--- a/components/chart/container/index.tsx
+++ b/components/chart/container/index.tsx
@@ -44,7 +44,8 @@ export default function ChartContainer() {
     currentSymbol,
     exchangeType,
     setCurrentSymbol,
-    setExchangeType, // リファクタリング中は一時的に古いメソッドを使用
+    // 新しいProductTypeメソッドを使用
+    setProductType,
     
     // チャートデータ関連
     chartData,
@@ -82,7 +83,7 @@ export default function ChartContainer() {
     currentSymbol: currentSymbol as string,
     exchangeType: exchangeType as ExchangeType,
     setCurrentSymbol,
-    setExchangeType, // リファクタリング中は一時的に古いメソッドを使用
+    setProductType,
     currentTimeFrame: currentTimeFrame as Timeframe,
     fetchData
   });
@@ -97,9 +98,9 @@ export default function ChartContainer() {
   }, [setCurrentSymbol]);
   
   const handleExchangeTypeChange = useCallback((newType: ProductType) => {
-    // 内部では型変換が行われるので、そのまま使用できる
-    setExchangeType(newType as unknown as ExchangeType);
-  }, [setExchangeType]);
+    // 内部で型変換が行われるのでそのまま使用
+    setProductType(newType);
+  }, [setProductType]);
   
   const handleChartTypeChange = useCallback((newType: ChartType) => {
     setChartType(newType);

--- a/components/chart/sections/ChartSection/ChartBody.tsx
+++ b/components/chart/sections/ChartSection/ChartBody.tsx
@@ -21,9 +21,9 @@ interface ChartBodyProps {
   error: string | null;
   currentSymbol: string;
   currentTimeFrame: Timeframe;
-  
+
   // アクション
-  setExchangeType: (type: ExchangeType) => void;
+  setProductType: (type: ExchangeType) => void;
   onRetry: () => void;
 }
 
@@ -38,7 +38,7 @@ export const ChartBody: React.FC<ChartBodyProps> = ({
   error,
   currentSymbol,
   currentTimeFrame,
-  setExchangeType,
+  setProductType,
   onRetry
 }) => {
   return (
@@ -59,7 +59,7 @@ export const ChartBody: React.FC<ChartBodyProps> = ({
                     {
                       label: 'Bitgetに切り替える',
                       action: () => {
-                        setExchangeType('bitget');
+                        setProductType('bitget');
                       }
                     }
                   ]

--- a/components/chart/sections/ChartSection/index.tsx
+++ b/components/chart/sections/ChartSection/index.tsx
@@ -84,7 +84,7 @@ export default function ChartSection() {
         error={chartDataStore.error}
         currentSymbol={symbolStore.currentSymbol}
         currentTimeFrame={chartDataStore.currentTimeFrame}
-        setExchangeType={symbolStore.setExchangeType}
+        setProductType={symbolStore.setProductType}
         onRetry={handleRetry}
       />
     </div>

--- a/components/chart/toolbar/__tests__/index.test.tsx
+++ b/components/chart/toolbar/__tests__/index.test.tsx
@@ -23,7 +23,7 @@ jest.mock('@/hooks/chart', () => ({
       currentSymbol: 'BTC-USD',
       exchangeType: 'spot',
       handleSymbolChange: jest.fn(),
-      setExchangeType: jest.fn()
+      setProductType: jest.fn()
     },
     chartDataStore: {
       chartData: [],

--- a/components/chart/toolbar/index.tsx
+++ b/components/chart/toolbar/index.tsx
@@ -90,7 +90,7 @@ const ChartToolbar = memo(function ChartToolbar({
           currentSymbol={symbolStore.currentSymbol}
           exchangeType={symbolStore.exchangeType as ExchangeProductType}
           onSymbolChange={symbolStore.handleSymbolChange}
-          onExchangeTypeChange={symbolStore.setExchangeType}
+          onExchangeTypeChange={symbolStore.setProductType}
           currentPrice={currentPrice}
           priceChangePercent={priceChangePercent}
           mounted={mounted}
@@ -151,7 +151,7 @@ const ChartToolbar = memo(function ChartToolbar({
           {/* 取引種別切り替えボタン */}
           <TradeTypeSwitch
             productType={symbolStore.exchangeType as ExchangeProductType}
-            onProductTypeChange={(type) => symbolStore.setExchangeType(type as ExchangeProductType)}
+            onProductTypeChange={(type) => symbolStore.setProductType(type as ExchangeProductType)}
           />
         </div>
       </div>

--- a/components/symbol/Selector/SymbolSelector.tsx
+++ b/components/symbol/Selector/SymbolSelector.tsx
@@ -181,18 +181,18 @@ const useSelectorStores = (options: {
   // ストアからアクションを取得
   const toggleFavorite = useRootStore(state => state.toggleFavorite);
   const fetchSymbols = useRootStore(state => state.fetchSymbols);
-  const setExchangeType = useRootStore(state => state.setExchangeType);
+  const setProductType = useRootStore(state => state.setProductType);
   const currentExchangeType = useRootStore(state => state.exchangeType);
   
   // 取引タイプの変更ハンドラー
   const handleExchangeTypeChange = useCallback((type: ExchangeType) => {
-    setExchangeType(type);
+    setProductType(type);
     
     // コールバックが提供されている場合、外部に変更を通知
     if (options.onExchangeTypeChange) {
       options.onExchangeTypeChange(type);
     }
-  }, [setExchangeType, options.onExchangeTypeChange]);
+  }, [setProductType, options.onExchangeTypeChange]);
   
   // 再試行ハンドラー
   const retryFetch = useCallback(() => {
@@ -202,9 +202,9 @@ const useSelectorStores = (options: {
   // デフォルトの取引タイプが指定されていれば設定
   useEffect(() => {
     if (options.defaultExchangeType && options.defaultExchangeType !== currentExchangeType) {
-      setExchangeType(options.defaultExchangeType);
+        setProductType(options.defaultExchangeType);
     }
-  }, [options.defaultExchangeType, currentExchangeType, setExchangeType]);
+  }, [options.defaultExchangeType, currentExchangeType, setProductType]);
   
   return {
     symbols: { filteredSymbols: symbols, isLoading, error },

--- a/docs/store-structure.md
+++ b/docs/store-structure.md
@@ -41,11 +41,11 @@ fetchData('BTC/USDT', '1d');
 import { useChartConfigStore } from '@/store';
 
 // 使用例
-const { 
+const {
   chartType,           // チャートタイプ（ローソク足、ライン、エリア）
   exchangeType,        // 取引種別（スポット、先物）
   setChartType,        // チャートタイプ設定関数
-  setExchangeType      // 取引種別設定関数
+  setProductType      // 取引種別設定関数
 } = useChartConfigStore();
 
 // チャートタイプの変更

--- a/hooks/chart/canvas/useChartEvents.ts
+++ b/hooks/chart/canvas/useChartEvents.ts
@@ -19,7 +19,7 @@ interface ChartEventProps {
   exchangeType: ExchangeType;
   setCurrentSymbol: (symbol: string, reason?: string) => void;
   // 更新: ProductType対応 (2025-05-17)
-  setExchangeType: (type: ExchangeType | ProductType) => void;
+  setProductType: (type: ExchangeType | ProductType) => void;
   // 将来的に追加予定
   // setProductType?: (type: ProductType) => void;
   
@@ -38,7 +38,7 @@ export const useChartEvents = ({
   currentSymbol,
   exchangeType,
   setCurrentSymbol,
-  setExchangeType,
+  setProductType,
   currentTimeFrame,
   fetchData
 }: ChartEventProps) => {
@@ -95,7 +95,7 @@ export const useChartEvents = ({
         });
         
         // 取引タイプを更新
-        setExchangeType(type);
+        setProductType(type);
         
         // 現物から先物への切り替えの場合、または銘柄が変更された場合は、取引タイプ変更後に銘柄を再設定
         if ((type === 'futures' && fromType === 'spot') || targetSymbol !== currentSymbol) {
@@ -120,7 +120,7 @@ export const useChartEvents = ({
     return () => {
       window.removeEventListener('instrumentTypeChanged', handleInstrumentTypeChange as EventListener);
     };
-  }, [exchangeType, currentSymbol, setExchangeType, setCurrentSymbol]);
+  }, [exchangeType, currentSymbol, setProductType, setCurrentSymbol]);
   
   // 銘柄変更イベントのリスナー
   useEffect(() => {

--- a/hooks/chart/canvas/useChartSectionStores.ts
+++ b/hooks/chart/canvas/useChartSectionStores.ts
@@ -48,7 +48,7 @@ export const useChartSectionStores = () => {
   const currentSymbol = useRootStore(selectCurrentSymbol);
   const exchangeType = useRootStore((state) => selectExchangeType(state as any));
   const setCurrentSymbol = useRootStore(state => state.setCurrentSymbol);
-  const setExchangeType = useRootStore(state => state.setExchangeType);
+  const setProductType = useRootStore(state => state.setProductType);
   
   // ChartDataStore (RootStoreから取得)
   const chartData = useRootStore((state) => selectChartData(state as any));
@@ -129,7 +129,7 @@ export const useChartSectionStores = () => {
       currentSymbol,
       exchangeType,
       setCurrentSymbol,
-      setExchangeType
+      setProductType
     },
     chartDataStore: {
       chartData,

--- a/hooks/chart/canvas/useChartStores.ts
+++ b/hooks/chart/canvas/useChartStores.ts
@@ -39,10 +39,8 @@ export const useChartStores = () => {
   const exchangeType = useRootStore(selectExchangeType as any);
   const setCurrentSymbol = useRootStore(state => state.setCurrentSymbol);
   
-  // 注: 今後のフェーズでsetProductTypeを追加予定
-  
   // 取引種別を設定するメソッド
-  const setExchangeType = useRootStore(state => state.setExchangeType);
+  const setProductType = useRootStore(state => state.setProductType);
   
   // rootStoreから直接取得 (型不一致を回避するために型アサーションを使用)
   const timeframe = useRootStore(selectTimeframe as any);
@@ -71,7 +69,7 @@ export const useChartStores = () => {
     currentSymbol,
     exchangeType,
     setCurrentSymbol,
-    setExchangeType,
+    setProductType,
     
     // チャートデータ関連
     chartData: ohlcData,

--- a/hooks/chart/toolbar/useChartToolbar.ts
+++ b/hooks/chart/toolbar/useChartToolbar.ts
@@ -52,7 +52,7 @@ export function useChartToolbar() {
   const chartType = useRootStore((state) => selectChartType(state as any));
   const exchangeType = useRootStore((state) => selectExchangeType(state as any));
   const setChartType = useRootStore((state) => state.setChartType);
-  const setExchangeType = useRootStore((state) => state.setExchangeType);
+  const setProductType = useRootStore((state) => state.setProductType);
 
   // リアルタイム更新の状態とアクションをrootStoreから取得
   const useRealTimeData = useRootStore((state) => state.useRealTimeData);
@@ -86,9 +86,9 @@ export function useChartToolbar() {
 
   // 取引種別変更ハンドラー
   const handleExchangeTypeChange = useCallback((type: ExchangeType) => {
-    setExchangeType(type);
+    setProductType(type);
     fetchData(currentSymbol, currentTimeFrame);
-  }, [setExchangeType, fetchData, currentSymbol, currentTimeFrame]);
+  }, [setProductType, fetchData, currentSymbol, currentTimeFrame]);
 
   // 型安全性を確保するためのヘルパー関数
   const isValidTimeframe = (timeframe: string): timeframe is Timeframe => {

--- a/hooks/chart/toolbar/useToolbarStores.ts
+++ b/hooks/chart/toolbar/useToolbarStores.ts
@@ -74,7 +74,7 @@ export function useToolbarStores() {
   // 型不一致を解決するためにセレクターをキャスト
   const exchangeType = useRootStore(selectExchangeType as any);
   const setCurrentSymbol = useRootStore(state => state.setCurrentSymbol);
-  const setExchangeType = useRootStore(state => state.setExchangeType);
+  const setProductType = useRootStore(state => state.setProductType);
   
   // ChartDataSliceから状態とアクションを取得（RootStoreを使用）
   const chartData = useRootStore(selectChartData);
@@ -146,7 +146,7 @@ export function useToolbarStores() {
       currentSymbol,
       exchangeType,
       setCurrentSymbol,
-      setExchangeType,
+      setProductType,
       handleSymbolChange
     },
     

--- a/hooks/chart/useChartEvents.ts
+++ b/hooks/chart/useChartEvents.ts
@@ -18,7 +18,7 @@ interface ChartEventProps {
   currentSymbol: string;
   exchangeType: ExchangeType;
   setCurrentSymbol: (symbol: string, reason?: string) => void;
-  setExchangeType: (type: ExchangeType) => void;
+  setProductType: (type: ExchangeType) => void;
   
   // チャートデータ関連
   currentTimeFrame: Timeframe;
@@ -35,7 +35,7 @@ export const useChartEvents = ({
   currentSymbol,
   exchangeType,
   setCurrentSymbol,
-  setExchangeType,
+  setProductType,
   currentTimeFrame,
   fetchData
 }: ChartEventProps) => {
@@ -90,7 +90,7 @@ export const useChartEvents = ({
         });
         
         // 取引タイプを更新
-        setExchangeType(type);
+        setProductType(type);
         
         // 現物から先物への切り替えの場合、または銘柄が変更された場合は、取引タイプ変更後に銘柄を再設定
         if ((type === 'futures' && fromType === 'spot') || targetSymbol !== currentSymbol) {
@@ -115,7 +115,7 @@ export const useChartEvents = ({
     return () => {
       window.removeEventListener('instrumentTypeChanged', handleInstrumentTypeChange as EventListener);
     };
-  }, [exchangeType, currentSymbol, setExchangeType, setCurrentSymbol]);
+  }, [exchangeType, currentSymbol, setProductType, setCurrentSymbol]);
   
   // 銘柄変更イベントのリスナー
   useEffect(() => {

--- a/hooks/chart/useChartSectionStores.ts
+++ b/hooks/chart/useChartSectionStores.ts
@@ -49,7 +49,7 @@ export const useChartSectionStores = () => {
   const currentSymbol = useRootStore(selectCurrentSymbol);
   const exchangeType = useRootStore(selectExchangeType);
   const setCurrentSymbol = useRootStore(state => state.setCurrentSymbol);
-  const setExchangeType = useRootStore(state => state.setExchangeType);
+  const setProductType = useRootStore(state => state.setProductType);
   
   // ChartDataStore (RootStoreから取得)
   const chartData = useRootStore(selectChartData);
@@ -130,7 +130,7 @@ export const useChartSectionStores = () => {
       currentSymbol,
       exchangeType,
       setCurrentSymbol,
-      setExchangeType
+      setProductType
     },
     chartDataStore: {
       chartData,

--- a/hooks/chart/useChartStores.ts
+++ b/hooks/chart/useChartStores.ts
@@ -38,7 +38,7 @@ export const useChartStores = () => {
   const currentSymbol = useRootStore(selectCurrentSymbol);
   const exchangeType = useRootStore(selectExchangeType);
   const setCurrentSymbol = useRootStore(state => state.setCurrentSymbol);
-  const setExchangeType = useRootStore(state => state.setExchangeType);
+  const setProductType = useRootStore(state => state.setProductType);
   
   // rootStoreから直接取得
   const timeframe = useRootStore(selectTimeframe);
@@ -67,7 +67,7 @@ export const useChartStores = () => {
     currentSymbol,
     exchangeType,
     setCurrentSymbol,
-    setExchangeType,
+    setProductType,
     
     // チャートデータ関連
     chartData: ohlcData,

--- a/hooks/chart/useToolbarStores.ts
+++ b/hooks/chart/useToolbarStores.ts
@@ -62,7 +62,7 @@ export function useToolbarStores() {
   const currentSymbol = useRootStore(selectCurrentSymbol);
   const exchangeType = useRootStore(selectExchangeType);
   const setCurrentSymbol = useRootStore(state => state.setCurrentSymbol);
-  const setExchangeType = useRootStore(state => state.setExchangeType);
+  const setProductType = useRootStore(state => state.setProductType);
   
   // ChartDataSliceから状態とアクションを取得（RootStoreを使用）
   const chartData = useRootStore(selectChartData);
@@ -115,7 +115,7 @@ export function useToolbarStores() {
       currentSymbol,
       exchangeType,
       setCurrentSymbol,
-      setExchangeType,
+      setProductType,
       handleSymbolChange
     },
     

--- a/store/symbol/index.ts
+++ b/store/symbol/index.ts
@@ -67,6 +67,9 @@ export const createSymbolSlice = (
     
     // SymbolActions のメソッド
     setCurrentSymbol: actions.setCurrentSymbol,
+    // 新しいProductTypeメソッドを公開
+    setProductType: actions.setProductType,
+    // 後方互換性のため旧メソッドも保持
     setExchangeType: actions.setExchangeType,
     setSymbols: (symbols: SymbolInfo[]) => {
       // 必要に応じて実装


### PR DESCRIPTION
## Summary
- add `setProductType` export in symbol slice
- update components and hooks to use `setProductType`
- adjust docs and tests for new API

## Testing
- `npm test` *(fails: Cannot find type definition file for 'jest')*