### PR TITLE
Fix tests for ProductType update

### DIFF
--- a/__tests__/api/api-refactor.test.ts
+++ b/__tests__/api/api-refactor.test.ts
@@ -8,7 +8,7 @@ import MockAdapter from 'axios-mock-adapter';
 // API関連のインポート
 import * as Api from '../../services/api/common/request';
 import { getApiClient } from '@/services/api/client-factory';
-import { ExchangeProductType } from '@/types/constants/enums';
+import { ProductType } from '@/types/constants/enums';
 import { handleApiError, handleWebSocketError, handleChartError } from '../../services/errors/handler';
 import { getApiConfig, IS_DEV, IS_BROWSER } from '../../services/api/common/environment';
 
@@ -134,7 +134,7 @@ describe('APIリファクタリングテスト', () => {
 
   describe('APIクライアントファクトリー', () => {
     it('正しいタイプのクライアントを返すこと', () => {
-      const client = getApiClient('spot' as ExchangeProductType);
+      const client = getApiClient('spot' as ProductType);
       expect(client).toBeDefined();
       expect(client.constructor.name).toBe('BitgetApiClient');
     });

--- a/__tests__/api/rest-client.test.ts
+++ b/__tests__/api/rest-client.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { OHLCData, OrderBookData } from '@/types/chart';
-import { ExchangeType, ExchangeProductType } from '@/types/constants/enums';
+import { ExchangeType, ProductType } from '@/types/constants/enums';
 import { BitgetRestClient } from '../../services/api/bitget/rest-client';
 import axios from 'axios';
 
@@ -41,7 +41,7 @@ describe('BitgetRestClient', () => {
     mockedAxios.get.mockResolvedValueOnce(mockResponse);
     
     // オーダーブックデータを取得
-    const result = await client.getOrderBook('BTC/USDT', 'spot' as ExchangeProductType);
+    const result = await client.getOrderBook('BTC/USDT', 'spot' as ProductType);
     
     // axiosが正しいエンドポイントとパラメータで呼び出されたことを確認
     expect(mockedAxios.get).toHaveBeenCalledWith(
@@ -67,7 +67,7 @@ describe('BitgetRestClient', () => {
     mockedAxios.get.mockRejectedValueOnce(new Error('Network error'));
     
     // オーダーブックデータを取得
-    const result = await client.getOrderBook('BTC/USDT', 'spot' as ExchangeProductType);
+    const result = await client.getOrderBook('BTC/USDT', 'spot' as ProductType);
     
     // デモデータが返されたことを確認
     expect(result).toEqual({

--- a/__tests__/services/data/chart-data-service.test.ts
+++ b/__tests__/services/data/chart-data-service.test.ts
@@ -12,8 +12,7 @@ import { cacheService } from '../../../services/cache/service';
 import { getSocketService } from '../../../services/socket/index';
 import { logger } from '../../../utils/logger';
 import { OHLCData } from '../../../types/chart';
-import { type ExchangeType } from '@/types/constants/enums';
-import { type ExchangeProductType } from '@/types/constants/enums';
+import { type ExchangeType, type ProductType } from '@/types/constants/enums';
 
 // ExchangeType用の定数
 const EXCHANGE_TYPES = {
@@ -21,10 +20,10 @@ const EXCHANGE_TYPES = {
   FUTURES: 'demo' as ExchangeType
 };
 
-// ExchangeProductType用の定数（チャートデータサービスが内部で使用している場合）
+// ProductType用の定数（チャートデータサービスが内部で使用している場合）
 const PRODUCT_TYPES = {
-  SPOT: 'spot' as ExchangeProductType,
-  FUTURES: 'futures' as ExchangeProductType
+  SPOT: 'spot' as ProductType,
+  FUTURES: 'futures' as ProductType
 };
 
 // モック

--- a/__tests__/unit/tools/instrument-type-tools.test.ts
+++ b/__tests__/unit/tools/instrument-type-tools.test.ts
@@ -5,7 +5,7 @@
 import { changeInstrumentTypeTool } from '../../../src/mastra/tools/instrument-type-tools';
 import { logger } from '../../../utils/logger';
 import fetch from 'node-fetch'; // Import to mock
-import { ExchangeType } from '../../../types/api';
+import { ExchangeType, ProductType } from '../../../types/api';
 
 // Mock logger
 jest.mock('../../../utils/logger', () => ({
@@ -59,7 +59,7 @@ describe('changeInstrumentTypeTool', () => {
   });
 
   it('取引タイプ変更ツールが正しくAPIを呼び出すこと (spot)', async () => {
-    const input = { context: { type: 'spot' as ExchangeType }, runtimeContext: mockRuntimeContext };
+    const input = { context: { type: 'spot' as ProductType }, runtimeContext: mockRuntimeContext };
     await changeInstrumentTypeTool.execute(input);
 
     expect(fetch).toHaveBeenCalledWith(
@@ -74,7 +74,7 @@ describe('changeInstrumentTypeTool', () => {
 
   it('取引タイプ変更ツールが正しくAPIを呼び出すこと (futures)', async () => {
     (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockApiResponse('futures'));
-    const input = { context: { type: 'futures' as ExchangeType, symbol: 'BTCUSDT' }, runtimeContext: mockRuntimeContext };
+    const input = { context: { type: 'futures' as ProductType, symbol: 'BTCUSDT' }, runtimeContext: mockRuntimeContext };
     await changeInstrumentTypeTool.execute(input);
 
     expect(fetch).toHaveBeenCalledWith(

--- a/__tests__/unit/tools/symbol-tools.test.ts
+++ b/__tests__/unit/tools/symbol-tools.test.ts
@@ -5,7 +5,7 @@
 import { changeSymbolTool } from '../../../src/mastra/tools/symbol-tools';
 import { logger } from '../../../utils/logger';
 import fetch from 'node-fetch'; // Import to mock
-import { ExchangeType } from '../../../types/api';
+import { ExchangeType, ProductType } from '../../../types/api';
 
 // Mock logger
 jest.mock('../../../utils/logger', () => ({
@@ -38,13 +38,13 @@ const createMockNodeFetchResponse = (body: any, options: { ok: boolean; status: 
   return response;
 };
 
-const mockSymbolApiResponse = (symbol: string, success = true, exchangeType?: ExchangeType) => 
+const mockSymbolApiResponse = (symbol: string, success = true, exchangeType?: ProductType) =>
   createMockNodeFetchResponse(
     { success, symbol, exchangeType }, 
     { ok: success, status: success ? 200 : 500, statusText: success ? 'OK' : 'Internal Server Error' }
   );
 
-const mockSymbolApiErrorResponse = (symbol: string, errorMessage: string, exchangeType?: ExchangeType) =>
+const mockSymbolApiErrorResponse = (symbol: string, errorMessage: string, exchangeType?: ProductType) =>
   createMockNodeFetchResponse(
     { success: false, symbol, error: errorMessage, exchangeType },
     { ok: false, status: 500, statusText: 'Internal Server Error' }
@@ -74,7 +74,7 @@ describe('changeSymbolTool', () => {
 
   it('取引タイプを指定して銘柄変更ができること', async () => {
     const inputSymbol = 'SOLUSDT';
-    const inputExchangeType = 'futures' as ExchangeType;
+    const inputExchangeType = 'futures' as ProductType;
     (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockSymbolApiResponse(inputSymbol, true, inputExchangeType));
     
     const input = { 

--- a/__tests__/unit/utils/socketClient.test.ts
+++ b/__tests__/unit/utils/socketClient.test.ts
@@ -1,5 +1,5 @@
 // 型のみをトップレベルでインポート
-import { ExchangeType } from '../../../types/api';
+import { ExchangeType, ProductType } from '../../../types/api';
 import { Timeframe } from '../../../types/chart';
 import type { Socket } from 'socket.io-client'; // Socket 型をインポート (DisconnectReason を削除)
 
@@ -272,7 +272,7 @@ describe('socketClient', () => {
       initializeSocketClient();
       const handler = getEventHandler('instrument-type-change'); // ユーザー指示ではこのイベント名は変更なし
       expect(handler).toBeDefined();
-      const eventData = { type: 'futures' as ExchangeType };
+      const eventData = { type: 'futures' as ProductType };
       if (handler) handler(eventData);
 
       // 3. ログ検証を構造化ログに対応
@@ -304,7 +304,7 @@ describe('socketClient', () => {
       initializeSocketClient();
       const handler = getEventHandler('instrument-type-change');
       expect(handler).toBeDefined();
-      const eventData = { type: 'spot' as ExchangeType };
+      const eventData = { type: 'spot' as ProductType };
       if (handler) handler(eventData);
 
       // 5. 例外系メッセージの修正

--- a/__tests__/validations/symbol.test.ts
+++ b/__tests__/validations/symbol.test.ts
@@ -10,7 +10,7 @@ import {
   filterOptionsSchema,
   symbolSelectorPropsSchema
 } from '@/types/validations/symbol';
-import { ExchangeProductType } from '@/types/constants/enums';
+import { type ProductType } from '@/types/constants/enums';
 
 describe('Symbol Validations', () => {
   describe('symbolInfoSchema', () => {
@@ -103,8 +103,8 @@ describe('Symbol Validations', () => {
       const validProps = {
         onSelect: (symbol: string) => {},
         currentSymbol: 'BTCUSDT',
-        defaultExchangeType: 'spot' as ExchangeProductType,
-        onExchangeTypeChange: (type: ExchangeProductType) => {}
+        defaultExchangeType: 'spot' as ProductType,
+        onExchangeTypeChange: (type: ProductType) => {}
       };
 
       const result = symbolSelectorPropsSchema.safeParse(validProps);
@@ -115,7 +115,7 @@ describe('Symbol Validations', () => {
       const invalidProps = {
         // onSelectが欠けている
         currentSymbol: 'BTCUSDT',
-        defaultExchangeType: 'spot' as ExchangeProductType
+        defaultExchangeType: 'spot' as ProductType
       };
 
       const result = symbolSelectorPropsSchema.safeParse(invalidProps);
@@ -126,7 +126,7 @@ describe('Symbol Validations', () => {
       const validProps = {
         onSelect: (symbol: string) => {},
         currentSymbol: 'BTCUSDT',
-        defaultExchangeType: 'spot' as ExchangeProductType
+        defaultExchangeType: 'spot' as ProductType
       };
 
       const result = validateSymbolSelectorProps(validProps);


### PR DESCRIPTION
## Summary
- update tests to use `ProductType`
- adjust imports and casts for new `ProductType` union

## Testing
- `npm run typecheck:test` *(fails: Cannot find type definition file for 'jest' and 'node')*
- `npm test` *(fails during pretest due to the same typecheck errors)*