### PR TITLE
Refactor Bitget client types

### DIFF
--- a/__tests__/services/socket/bitget-integration.test.ts
+++ b/__tests__/services/socket/bitget-integration.test.ts
@@ -7,7 +7,7 @@
 
 import { BitgetIntegration } from '../../../services/socket/bitget-integration';
 import { BitgetApiClient } from '../../../services/api/bitget/client';
-import { ExchangeType } from '../../../types/api';
+import { ProductType } from '../../../types/api';
 import { logger } from '../../../utils/logger';
 
 // BitgetApiClientのモック
@@ -45,7 +45,7 @@ describe('BitgetIntegration', () => {
   describe('initializeApiClient', () => {
     it('新しいBitgetApiClientを初期化できること', () => {
       // initializeApiClientを実行
-      const apiClient = bitgetIntegration.initializeApiClient('spot');
+      const apiClient = bitgetIntegration.initializeApiClient('spot' as ProductType);
       
       // 結果を検証
       expect(BitgetApiClient).toHaveBeenCalledWith({}, 'spot');
@@ -62,13 +62,13 @@ describe('BitgetIntegration', () => {
     
     it('既存のAPIクライアントがある場合は切断してから新しいクライアントを作成すること', () => {
       // 1回目の初期化
-      const firstClient = bitgetIntegration.initializeApiClient('spot');
+      const firstClient = bitgetIntegration.initializeApiClient('spot' as ProductType);
       
       // モックをリセット
       jest.clearAllMocks();
       
       // 2回目の初期化
-      const secondClient = bitgetIntegration.initializeApiClient('futures');
+      const secondClient = bitgetIntegration.initializeApiClient('futures' as ProductType);
       
       // 結果を検証
       expect(firstClient.disconnectWebSocket).toHaveBeenCalled();
@@ -83,7 +83,7 @@ describe('BitgetIntegration', () => {
       });
       
       // initializeApiClientを実行
-      const apiClient = bitgetIntegration.initializeApiClient('spot');
+      const apiClient = bitgetIntegration.initializeApiClient('spot' as ProductType);
       
       // 結果を検証
       expect(logger.error).toHaveBeenCalledWith(
@@ -103,7 +103,7 @@ describe('BitgetIntegration', () => {
   describe('getCurrentApiClient', () => {
     it('現在のAPIクライアントを取得できること', () => {
       // APIクライアントを初期化
-      const apiClient = bitgetIntegration.initializeApiClient('spot');
+      const apiClient = bitgetIntegration.initializeApiClient('spot' as ProductType);
       
       // getCurrentApiClientを実行
       const currentClient = bitgetIntegration.getCurrentApiClient();
@@ -124,7 +124,7 @@ describe('BitgetIntegration', () => {
   describe('disconnectApiClient', () => {
     it('APIクライアントを切断できること', () => {
       // APIクライアントを初期化
-      const apiClient = bitgetIntegration.initializeApiClient('spot');
+      const apiClient = bitgetIntegration.initializeApiClient('spot' as ProductType);
       
       // disconnectApiClientを実行
       bitgetIntegration.disconnectApiClient();
@@ -150,7 +150,7 @@ describe('BitgetIntegration', () => {
     
     it('切断中にエラーが発生した場合はログを出力すること', () => {
       // APIクライアントを初期化
-      const apiClient = bitgetIntegration.initializeApiClient('spot');
+      const apiClient = bitgetIntegration.initializeApiClient('spot' as ProductType);
       
       // disconnectWebSocketでエラーを発生させる
       (apiClient.disconnectWebSocket as jest.Mock).mockImplementation(() => {

--- a/__tests__/services/socket/socket-service.test.ts
+++ b/__tests__/services/socket/socket-service.test.ts
@@ -10,7 +10,7 @@ import { SocketService } from '../../../services/socket/socket-service';
 import { IWebSocketClient, ISubscriptionManager, IBitgetIntegration } from '../../../services/socket/interfaces';
 import { OrderBookData } from '../../../types/market';
 import { OHLCData } from '../../../types/chart';
-import { ExchangeType } from '../../../types/api';
+import { ProductType } from '../../../types/api';
 import { BitgetApiClient } from '../../../services/api/bitget/client';
 import { logger } from '../../../utils/logger';
 
@@ -106,7 +106,7 @@ describe('SocketService', () => {
   describe('initializeApiClient', () => {
     it('BitgetIntegrationのinitializeApiClientを呼び出すこと', () => {
       // initializeApiClientを実行
-      const result = socketService.initializeApiClient('spot');
+      const result = socketService.initializeApiClient('spot' as ProductType);
       
       // 結果を検証
       expect(mockBitgetIntegration.initializeApiClient).toHaveBeenCalledWith('spot', {});
@@ -118,7 +118,7 @@ describe('SocketService', () => {
       const config = { demo: true, reconnect: false };
       
       // initializeApiClientを実行
-      socketService.initializeApiClient('futures', config);
+      socketService.initializeApiClient('futures' as ProductType, config);
       
       // 結果を検証
       expect(mockBitgetIntegration.initializeApiClient).toHaveBeenCalledWith('futures', config);
@@ -158,7 +158,7 @@ describe('SocketService', () => {
       const callback = jest.fn();
       
       // subscribeOrderBookを実行
-      socketService.subscribeOrderBook('BTC/USDT', callback, 'futures');
+      socketService.subscribeOrderBook('BTC/USDT', callback, 'futures' as ProductType);
       
       // 結果を検証
       expect(mockSubscriptionManager.subscribeOrderBook).toHaveBeenCalledWith(
@@ -192,7 +192,7 @@ describe('SocketService', () => {
       const callback = jest.fn();
       
       // subscribeKlineを実行
-      socketService.subscribeKline('BTC/USDT', '1m', callback, 'futures');
+      socketService.subscribeKline('BTC/USDT', '1m', callback, 'futures' as ProductType);
       
       // 結果を検証
       expect(mockSubscriptionManager.subscribeKline).toHaveBeenCalledWith(

--- a/__tests__/services/socket/subscription-manager.test.ts
+++ b/__tests__/services/socket/subscription-manager.test.ts
@@ -11,7 +11,7 @@ import { SubscriptionManager, CHANNEL } from '../../../services/socket/subscript
 import { IWebSocketClient } from '../../../services/socket/interfaces';
 import { OrderBookData } from '../../../types/market';
 import { OHLCData } from '../../../types/chart';
-import { ExchangeType } from '../../../types/api';
+import { ProductType } from '../../../types/api';
 
 // WebSocketClientとloggerのモジュールをモック
 jest.mock('../../../services/socket/websocket-client', () => ({

--- a/services/api/bitget/client.new.ts
+++ b/services/api/bitget/client.new.ts
@@ -9,7 +9,7 @@
  * 既存の実装との互換性を保ちながら、段階的なリファクタリングを可能にします。
  */
 
-import { ExchangeType, ProductType, BitgetCredentials } from '../../../types/api';
+import { ProductType, BitgetCredentials } from '../../../types/api';
 import { OHLCData } from '../../../types/chart';
 import { OrderBookData } from '../../../types/market';
 import { IRestApiClient, IWebSocketClient } from '../interfaces';
@@ -39,7 +39,6 @@ export class BitgetApiClient implements IBitgetApiClient {
   private wsUrl: string;
   private enableDemoMode: boolean;
   private productType: ProductType = 'spot';
-  private exchangeType: ExchangeType;
   private isInDemoMode: boolean = false;
   
   // コンポーネント
@@ -52,9 +51,8 @@ export class BitgetApiClient implements IBitgetApiClient {
    * BitgetApiClientのコンストラクタ
    * @param options クライアントオプション
    * @param productType 取引種別（'spot'または'futures'、デフォルト: 'spot'）
-   * @param exchangeType 取引所タイプ（デフォルト: 'bitget'）
    */
-  constructor(options: BitgetApiClientOptions = {}, productType: ProductType = 'spot', exchangeType: ExchangeType = 'bitget') {
+  constructor(options: BitgetApiClientOptions = {}, productType: ProductType = 'spot') {
     // API設定を環境設定から取得
     const apiConfig = getApiConfig('bitget');
     
@@ -63,15 +61,13 @@ export class BitgetApiClient implements IBitgetApiClient {
     this.wsUrl = options.wsUrl || apiConfig.wsUrl;
     this.enableDemoMode = options.enableDemoMode !== undefined ? options.enableDemoMode : apiConfig.enableDemoMode;
     this.productType = productType;
-    this.exchangeType = exchangeType;
     
     // コンポーネントの初期化
     this.restClient = new BitgetRestClient();
     this.wsClient = new BitgetWebSocketClient({
       wsUrl: this.wsUrl,
       credentials: this.credentials,
-      productType: this.productType,
-      exchangeType: this.exchangeType
+      productType: this.productType
     });
     this.dataTransformer = new BitgetDataTransformer();
     this.demoGenerator = new BitgetDemoGenerator();
@@ -79,7 +75,7 @@ export class BitgetApiClient implements IBitgetApiClient {
     logger.info('BitgetApiClient initialized', {
       component: 'BitgetApiClient',
       action: 'constructor',
-      exchangeType: this.exchangeType,
+      productType: this.productType,
       baseUrl: this.baseUrl
     });
   }
@@ -159,7 +155,7 @@ export class BitgetApiClient implements IBitgetApiClient {
     symbol: string,
     timeframe: string,
     limit: number = 100,
-    type: ExchangeType = 'bitget'
+    productType: ProductType = this.productType
   ): Promise<OHLCData[]> {
     try {
       logger.info(`Fetching candles for ${symbol} with timeframe ${timeframe}`, {
@@ -168,11 +164,11 @@ export class BitgetApiClient implements IBitgetApiClient {
         symbol,
         timeframe,
         limit,
-        type
+        productType
       });
       
       // REST APIクライアントを使用してデータを取得
-      return await this.restClient.fetchCandles(symbol, timeframe, limit);
+      return await this.restClient.fetchCandles(symbol, timeframe, limit, productType);
     } catch (error) {
       logger.error(`Failed to fetch candles: ${error}`, {
         component: 'BitgetApiClient',
@@ -207,7 +203,7 @@ export class BitgetApiClient implements IBitgetApiClient {
   async fetchOrderBook(
     symbol: string,
     limit: number = 20,
-    type: ExchangeType = 'bitget'
+    productType: ProductType = this.productType
   ): Promise<OrderBookData> {
     try {
       logger.info(`Fetching order book for ${symbol}`, {
@@ -215,11 +211,11 @@ export class BitgetApiClient implements IBitgetApiClient {
         action: 'fetchOrderBook',
         symbol,
         limit,
-        type
+        productType
       });
       
       // REST APIクライアントを使用してデータを取得
-      return await this.restClient.fetchOrderBook(symbol, limit, type);
+      return await this.restClient.fetchOrderBook(symbol, limit, productType);
     } catch (error) {
       logger.error(`Failed to fetch order book: ${error}`, {
         component: 'BitgetApiClient',

--- a/services/api/bitget/client.ts
+++ b/services/api/bitget/client.ts
@@ -9,7 +9,7 @@
  * 既存の実装との互換性を保ちながら、段階的なリファクタリングを可能にします。
  */
 
-import { ExchangeType, ProductType, BitgetCredentials } from '../../../types/api';
+import { ProductType, BitgetCredentials } from '../../../types/api';
 import { OHLCData } from '../../../types/chart';
 import { OrderBookData } from '../../../types/market';
 import { IRestApiClient, IWebSocketClient } from '../interfaces';
@@ -39,8 +39,6 @@ export class BitgetApiClient implements IBitgetApiClient {
   private wsUrl: string;
   private enableDemoMode: boolean;
   private productType: ProductType = 'spot';
-  // 旧実装との互換性のためにExchangeTypeも保持
-  private exchangeType: ExchangeType;
   private isInDemoMode: boolean = false;
   
   // コンポーネント
@@ -53,9 +51,8 @@ export class BitgetApiClient implements IBitgetApiClient {
    * BitgetApiClientのコンストラクタ
    * @param options クライアントオプション
    * @param productType 取引種別（'spot'または'futures'、デフォルト: 'spot'）
-   * @param exchangeType 取引所タイプ（デフォルト: 'bitget'）
    */
-  constructor(options: BitgetApiClientOptions = {}, productType: ProductType = 'spot', exchangeType: ExchangeType = 'bitget') {
+  constructor(options: BitgetApiClientOptions = {}, productType: ProductType = 'spot') {
     // API設定を環境設定から取得
     const apiConfig = getApiConfig('bitget');
     
@@ -64,15 +61,13 @@ export class BitgetApiClient implements IBitgetApiClient {
     this.wsUrl = options.wsUrl || apiConfig.wsUrl;
     this.enableDemoMode = options.enableDemoMode !== undefined ? options.enableDemoMode : apiConfig.enableDemoMode;
     this.productType = productType;
-    this.exchangeType = exchangeType;
     
     // コンポーネントの初期化
     this.restClient = new BitgetRestClient();
     this.wsClient = new BitgetWebSocketClient({
       wsUrl: this.wsUrl,
       credentials: this.credentials,
-      productType: this.productType,
-      exchangeType: this.exchangeType
+      productType: this.productType
     });
     this.dataTransformer = new BitgetDataTransformer();
     this.demoGenerator = new BitgetDemoGenerator();
@@ -81,7 +76,6 @@ export class BitgetApiClient implements IBitgetApiClient {
       component: 'BitgetApiClient',
       action: 'constructor',
       productType: this.productType,
-      exchangeType: this.exchangeType,
       baseUrl: this.baseUrl
     });
   }
@@ -161,7 +155,7 @@ export class BitgetApiClient implements IBitgetApiClient {
     symbol: string,
     timeframe: string,
     limit: number = 100,
-    type: ExchangeType = 'bitget'
+    productType: ProductType = this.productType
   ): Promise<OHLCData[]> {
     try {
       logger.info(`Fetching candles for ${symbol} with timeframe ${timeframe}`, {
@@ -170,12 +164,12 @@ export class BitgetApiClient implements IBitgetApiClient {
         symbol,
         timeframe,
         limit,
-        type
+        productType
       });
       
       // REST APIクライアントを使用してデータを取得
       // 取引タイプを正しく渡す
-      return await this.restClient.fetchCandles(symbol, timeframe, limit, type);
+      return await this.restClient.fetchCandles(symbol, timeframe, limit, productType);
     } catch (error) {
       logger.error(`Failed to fetch candles: ${error}`, {
         component: 'BitgetApiClient',
@@ -210,7 +204,7 @@ export class BitgetApiClient implements IBitgetApiClient {
   async fetchOrderBook(
     symbol: string,
     limit: number = 20,
-    type: ExchangeType = 'bitget'
+    productType: ProductType = this.productType
   ): Promise<OrderBookData> {
     try {
       logger.info(`Fetching order book for ${symbol}`, {
@@ -218,11 +212,11 @@ export class BitgetApiClient implements IBitgetApiClient {
         action: 'fetchOrderBook',
         symbol,
         limit,
-        type
+        productType
       });
       
       // REST APIクライアントを使用してデータを取得
-      return await this.restClient.fetchOrderBook(symbol, limit, type);
+      return await this.restClient.fetchOrderBook(symbol, limit, productType);
     } catch (error) {
       logger.error(`Failed to fetch order book: ${error}`, {
         component: 'BitgetApiClient',

--- a/services/api/bitget/interfaces.ts
+++ b/services/api/bitget/interfaces.ts
@@ -8,7 +8,7 @@
  * 既存の実装との互換性を保ちながら、段階的なリファクタリングを可能にします。
  */
 
-import { ExchangeType, BitgetCredentials } from '../../../types/api';
+import { ProductType, BitgetCredentials } from '../../../types/api';
 import { OHLCData } from '../../../types/chart';
 import { OrderBookData } from '../../../types/market';
 import { IRestApiClient, IWebSocketClient } from '../interfaces';
@@ -65,7 +65,7 @@ export interface IBitgetApiClient {
     symbol: string,
     timeframe: string,
     limit?: number,
-    type?: ExchangeType
+    type?: ProductType
   ): Promise<OHLCData[]>;
   
   /**
@@ -78,7 +78,7 @@ export interface IBitgetApiClient {
   fetchOrderBook(
     symbol: string,
     limit?: number,
-    type?: ExchangeType
+    type?: ProductType
   ): Promise<OrderBookData>;
   
   /**

--- a/services/api/bitget/ws-client.new.ts
+++ b/services/api/bitget/ws-client.new.ts
@@ -8,7 +8,7 @@
  * 接続管理、メッセージ送受信、Ping/Pong処理、再接続ロジックを実装します。
  */
 
-import { ExchangeType, BitgetCredentials } from '../../../types/api';
+import { ProductType, BitgetCredentials } from '../../../types/api';
 import { OHLCData, Timeframe } from '../../../types/chart';
 import { OrderBookData } from '../../../types/market';
 import { logger } from '@/utils/common';
@@ -34,9 +34,9 @@ export interface WebSocketClientOptions {
   credentials?: BitgetCredentials;
   
   /**
-   * 取引タイプ
+   * 取引種別
    */
-  exchangeType?: ExchangeType;
+  productType?: ProductType;
 }
 
 /**
@@ -46,7 +46,7 @@ export interface WebSocketClientOptions {
 export class BitgetWebSocketClient extends EventEmitter {
   private wsUrl: string;
   private credentials: BitgetCredentials;
-  private exchangeType: ExchangeType;
+  private productType: ProductType;
   private ws: WebSocket | null = null;
   private pingInterval: ReturnType<typeof setInterval> | null = null;
   private reconnectInterval: ReturnType<typeof setTimeout> | null = null;
@@ -69,13 +69,13 @@ export class BitgetWebSocketClient extends EventEmitter {
     
     this.wsUrl = options.wsUrl || apiConfig.wsUrl;
     this.credentials = options.credentials || {};
-    this.exchangeType = options.exchangeType || 'spot';
+    this.productType = options.productType || 'spot';
     this.dataTransformer = new BitgetDataTransformer();
     
     logger.info('BitgetWebSocketClient initialized', {
       component: 'BitgetWebSocketClient',
       action: 'constructor',
-      exchangeType: this.exchangeType,
+      productType: this.productType,
       wsUrl: this.wsUrl
     });
   }
@@ -218,13 +218,13 @@ export class BitgetWebSocketClient extends EventEmitter {
     this.onOrderBookUpdateCallbacks.set(symbol, callbacks);
     
     // 購読情報を作成
-    const instId = this.exchangeType === 'spot' ? 
-      `${formattedSymbol}_SPBL` : 
+    const instId = this.productType === 'spot' ?
+      `${formattedSymbol}_SPBL` :
       `${formattedSymbol}_UMCBL`;
     
     // 購読リクエストを送信
     const subscription = {
-      instType: this.exchangeType.toUpperCase(),
+      instType: this.productType.toUpperCase(),
       channel: 'books',
       instId
     };
@@ -270,13 +270,13 @@ export class BitgetWebSocketClient extends EventEmitter {
     this.onKlineUpdateCallbacks.set(key, callbacks);
     
     // 購読情報を作成
-    const instId = this.exchangeType === 'spot' ? 
-      `${formattedSymbol}_SPBL` : 
+    const instId = this.productType === 'spot' ?
+      `${formattedSymbol}_SPBL` :
       `${formattedSymbol}_UMCBL`;
     
     // 購読リクエストを送信
     const subscription = {
-      instType: this.exchangeType.toUpperCase(),
+      instType: this.productType.toUpperCase(),
       channel: `candle${timeframe}`,
       instId
     };

--- a/services/socket/bitget-integration.ts
+++ b/services/socket/bitget-integration.ts
@@ -6,7 +6,7 @@
  * 変更: index.tsからBitgetAPI統合機能を分離
  */
 
-import { ExchangeType } from '../../types/api';
+import { ProductType } from '../../types/api';
 import { BitgetApiClient } from '../api/bitget/client';
 import { logger } from '../../utils/logger';
 import { IBitgetIntegration } from './interfaces';
@@ -20,11 +20,11 @@ export class BitgetIntegration implements IBitgetIntegration {
 
   /**
    * BitgetAPIクライアントを初期化
-   * @param exchangeType 取引タイプ（'spot'または'futures'）
+   * @param exchangeType 取引種別（'spot'または'futures'）
    * @param config 追加の設定オプション
    * @returns BitgetAPIクライアントインスタンス
    */
-  initializeApiClient(exchangeType: ExchangeType, config: Record<string, any> = {}): BitgetApiClient {
+  initializeApiClient(productType: ProductType, config: Record<string, any> = {}): BitgetApiClient {
     try {
       // 既存のAPIクライアントがあれば切断
       if (this.bitgetApi) {
@@ -32,12 +32,12 @@ export class BitgetIntegration implements IBitgetIntegration {
       }
       
       // 新しいAPIクライアントを作成
-      this.bitgetApi = new BitgetApiClient(config, exchangeType);
+      this.bitgetApi = new BitgetApiClient(config, productType);
       
       logger.info('BitgetApiClient初期化成功', {
         component: 'BitgetIntegration',
         action: 'initializeApiClient',
-        exchangeType
+        productType
       });
       
       return this.bitgetApi;
@@ -45,12 +45,12 @@ export class BitgetIntegration implements IBitgetIntegration {
       logger.error('BitgetApiClient初期化エラー:', error, {
         component: 'BitgetIntegration',
         action: 'initializeApiClient',
-        exchangeType,
+        productType,
         error
       });
       
       // エラーが発生した場合でもクライアントを返す（エラーハンドリングは呼び出し側で行う）
-      this.bitgetApi = new BitgetApiClient(config, exchangeType);
+      this.bitgetApi = new BitgetApiClient(config, productType);
       return this.bitgetApi;
     }
   }

--- a/services/socket/interfaces.ts
+++ b/services/socket/interfaces.ts
@@ -9,7 +9,7 @@
 import { Socket } from 'socket.io-client';
 import { OrderBookData } from '../../types/market';
 import { OHLCData, Timeframe } from '../../types/chart';
-import { ExchangeType } from '../../types/api';
+import { ProductType } from '../../types/api';
 
 /**
  * WebSocket接続管理インターフェース
@@ -60,7 +60,7 @@ export interface ISubscriptionManager {
   subscribeOrderBook(
     symbol: string,
     callback: (data: OrderBookData) => void,
-    exchangeType?: ExchangeType
+    exchangeType?: ProductType
   ): () => void;
   
   /**
@@ -75,7 +75,7 @@ export interface ISubscriptionManager {
     symbol: string,
     timeframe: Timeframe,
     callback: (data: OHLCData) => void,
-    exchangeType?: ExchangeType
+    exchangeType?: ProductType
   ): () => void;
   
   /**
@@ -88,7 +88,7 @@ export interface ISubscriptionManager {
   subscribeTrades(
     symbol: string,
     callback: (data: any) => void,
-    exchangeType?: ExchangeType
+    exchangeType?: ProductType
   ): () => void;
   
   /**
@@ -114,7 +114,7 @@ export interface IBitgetIntegration {
    * @returns BitgetAPIクライアントインスタンス
    */
   initializeApiClient(
-    exchangeType: ExchangeType,
+    exchangeType: ProductType,
     config?: Record<string, any>
   ): any;
   
@@ -148,7 +148,7 @@ export interface ISocketService {
    * @returns BitgetAPIクライアントインスタンス
    */
   initializeApiClient(
-    exchangeType: ExchangeType,
+    exchangeType: ProductType,
     config?: Record<string, any>
   ): any;
   
@@ -168,7 +168,7 @@ export interface ISocketService {
   subscribeOrderBook(
     symbol: string,
     callback: (data: OrderBookData) => void,
-    exchangeType?: ExchangeType
+    exchangeType?: ProductType
   ): () => void;
   
   /**
@@ -183,7 +183,7 @@ export interface ISocketService {
     symbol: string,
     timeframe: Timeframe,
     callback: (data: OHLCData) => void,
-    exchangeType?: ExchangeType
+    exchangeType?: ProductType
   ): () => void;
   
   /**

--- a/services/socket/mock-service.ts
+++ b/services/socket/mock-service.ts
@@ -9,7 +9,7 @@
 import { EventEmitter } from 'events';
 import { OrderBookData, OrderBookEntry } from '@/types/common/orderbook';
 import { OHLCData, Timeframe } from '../../types/chart';
-import { ExchangeType } from '../../types/api';
+import { ProductType } from '../../types/api';
 import { logger } from '../../utils/logger';
 import { ISocketService } from './interfaces';
 
@@ -143,7 +143,7 @@ export class MockSocketService extends EventEmitter implements ISocketService {
   subscribeOrderBook(
     symbol: string,
     callback: (data: OrderBookData) => void,
-    exchangeType: ExchangeType = 'bitget'
+    exchangeType: ProductType = 'spot'
   ): () => void {
     const subKey = `orderbook:${symbol}:${exchangeType}`;
     this.mockSubscriptions.set(subKey, callback);
@@ -178,7 +178,7 @@ export class MockSocketService extends EventEmitter implements ISocketService {
     symbol: string,
     timeframe: Timeframe,
     callback: (data: OHLCData) => void,
-    exchangeType: ExchangeType = 'bitget'
+    exchangeType: ProductType = 'spot'
   ): () => void {
     const subKey = `kline:${symbol}:${timeframe}:${exchangeType}`;
     this.mockSubscriptions.set(subKey, callback);

--- a/services/socket/socket-service.ts
+++ b/services/socket/socket-service.ts
@@ -9,7 +9,7 @@
 import { Socket } from 'socket.io-client';
 import { OrderBookData } from '../../types/market';
 import { OHLCData, Timeframe } from '../../types/chart';
-import { ExchangeType } from '../../types/api';
+import { ProductType } from '../../types/api';
 import { BitgetApiClient } from '../api/bitget/client';
 import { logger } from '../../utils/logger';
 import { 
@@ -71,7 +71,7 @@ export class SocketService implements ISocketService {
    * @param config 追加の設定オプション
    * @returns BitgetAPIクライアントインスタンス
    */
-  initializeApiClient(exchangeType: ExchangeType, config: Record<string, any> = {}): BitgetApiClient {
+  initializeApiClient(exchangeType: ProductType, config: Record<string, any> = {}): BitgetApiClient {
     return this.bitgetIntegration.initializeApiClient(exchangeType, config);
   }
 
@@ -93,7 +93,7 @@ export class SocketService implements ISocketService {
   subscribeOrderBook(
     symbol: string,
     callback: (data: OrderBookData) => void,
-    exchangeType: ExchangeType = 'bitget'
+    exchangeType: ProductType = 'spot'
   ): () => void {
     return this.subscriptionManager.subscribeOrderBook(symbol, callback, exchangeType);
   }
@@ -110,7 +110,7 @@ export class SocketService implements ISocketService {
     symbol: string,
     timeframe: Timeframe,
     callback: (data: OHLCData) => void,
-    exchangeType: ExchangeType = 'bitget'
+    exchangeType: ProductType = 'spot'
   ): () => void {
     return this.subscriptionManager.subscribeKline(symbol, timeframe, callback, exchangeType);
   }

--- a/services/socket/subscription-manager.ts
+++ b/services/socket/subscription-manager.ts
@@ -9,7 +9,7 @@
 import { Socket } from 'socket.io-client';
 import { OrderBookData } from '../../types/market';
 import { OHLCData, Timeframe } from '../../types/chart';
-import { ExchangeType } from '../../types/api';
+import { ProductType } from '../../types/api';
 import { normalizeSymbol } from '../../lib/utils';
 import { logger } from '../../utils/logger';
 import { ISubscriptionManager, IWebSocketClient } from './interfaces';
@@ -30,7 +30,7 @@ export const CHANNEL = {
 interface SubscriptionInfo {
   symbol: string;
   type: string;
-  exchangeType: ExchangeType;
+  exchangeType: ProductType;
   timeframe?: Timeframe;
   callback: Function;
   handler: Function;
@@ -65,7 +65,7 @@ export class SubscriptionManager implements ISubscriptionManager {
   subscribeOrderBook(
     symbol: string,
     callback: (data: OrderBookData) => void,
-    exchangeType: ExchangeType = 'bitget'
+    exchangeType: ProductType = 'spot'
   ): () => void {
     try {
       const socket = this.webSocketClient.getSocket();
@@ -176,7 +176,7 @@ export class SubscriptionManager implements ISubscriptionManager {
     symbol: string,
     timeframe: Timeframe,
     callback: (data: OHLCData) => void,
-    exchangeType: ExchangeType = 'bitget'
+    exchangeType: ProductType = 'spot'
   ): () => void {
     try {
       const socket = this.webSocketClient.getSocket();
@@ -275,7 +275,7 @@ export class SubscriptionManager implements ISubscriptionManager {
   subscribeTrades(
     symbol: string,
     callback: (data: any) => void,
-    exchangeType: ExchangeType = 'bitget'
+    exchangeType: ProductType = 'spot'
   ): () => void {
     try {
       const socket = this.webSocketClient.getSocket();


### PR DESCRIPTION
## Summary
- replace `exchangeType` with `productType` for Bitget clients
- update ws client to use `productType`
- adjust service layer and tests

## Testing
- `npm test` *(fails: Cannot find type definition file for 'jest')*