### PR TITLE
Fix tests type hint

### DIFF
--- a/__tests__/integration/data-flow/instrument-type-change-flow.test.ts
+++ b/__tests__/integration/data-flow/instrument-type-change-flow.test.ts
@@ -6,6 +6,7 @@
 import { changeInstrumentTypeTool } from '../../../src/mastra/tools/instrument-type-tools';
 import { socketStoreActions } from '../../../store/socketActions';
 import { logger } from '../../../utils/common';
+import { ProductType } from '../../../types/api';
 
 // モジュールをモック化
 jest.mock('../../../src/mastra/tools/instrument-type-tools', () => ({
@@ -37,7 +38,7 @@ const mockRuntimeContext: any = {
   userId: 'test-user-id',
 };
 
-const mockApiResponse = (type: 'spot' | 'futures', success = true): Response => ({
+const mockApiResponse = (type: ProductType, success = true): Response => ({
   ok: success,
   json: jest.fn().mockResolvedValue({ success, type }),
   status: success ? 200 : 500,

--- a/__tests__/unit/tools/instrument-type-tools.test.ts
+++ b/__tests__/unit/tools/instrument-type-tools.test.ts
@@ -38,13 +38,13 @@ const createMockNodeFetchResponse = (body: any, options: { ok: boolean; status: 
   return response;
 };
 
-const mockApiResponse = (type: 'spot' | 'futures', success = true) => 
+const mockApiResponse = (type: ProductType, success = true) =>
   createMockNodeFetchResponse(
     { success, type }, 
     { ok: success, status: success ? 200 : 500, statusText: success ? 'OK' : 'Internal Server Error' }
   );
 
-const mockApiErrorResponseText = (errorMessage: string, type: 'spot' | 'futures') =>
+const mockApiErrorResponseText = (errorMessage: string, type: ProductType) =>
   createMockNodeFetchResponse(
     { success: false, error: errorMessage, type },
     { ok: false, status: 500, statusText: 'Internal Server Error' }


### PR DESCRIPTION
## Summary
- replace `'spot' | 'futures'` with `ProductType` in tests

## Testing
- `npm test --silent` *(fails: Cannot find type definition file for 'jest')*