### PR TITLE
Update chart types and test constants

### DIFF
--- a/__tests__/hooks/chat/useQuickCommands.test.tsx
+++ b/__tests__/hooks/chat/useQuickCommands.test.tsx
@@ -9,7 +9,7 @@ import { logger } from '@/utils/common';
 const DummyIcon = 'dummy-icon';
 
 // useQuickCommandsフックのモックを作成
-const mockQuickCommands = [
+const MockQuickCommands = [
   {
     label: "Entry Point",
     value: "Entry Point",
@@ -41,7 +41,7 @@ jest.mock('@/utils/logger', () => ({
 jest.mock('@/components/chat/section/hooks/useQuickCommands', () => {
   return {
     __esModule: true,
-    default: () => mockQuickCommands,
+    default: () => MockQuickCommands,
   };
 });
 
@@ -53,7 +53,7 @@ describe('useQuickCommands', () => {
 
   test('クイックコマンドの配列が正しい構造を持つこと', () => {
     // 各コマンドが正しいプロパティを持つことを確認
-    mockQuickCommands.forEach(command => {
+    MockQuickCommands.forEach(command => {
       expect(command).toHaveProperty('label');
       expect(command).toHaveProperty('value');
       expect(command).toHaveProperty('icon');
@@ -62,12 +62,12 @@ describe('useQuickCommands', () => {
     });
     
     // コマンド数が3つであることを確認
-    expect(mockQuickCommands.length).toBe(3);
+    expect(MockQuickCommands.length).toBe(3);
   });
   
   test('Entry Pointコマンドのアクションが正しく動作すること', () => {
     // Entry Pointコマンドを見つける
-    const entryPointCommand = mockQuickCommands.find(cmd => cmd.label === 'Entry Point');
+    const entryPointCommand = MockQuickCommands.find(cmd => cmd.label === 'Entry Point');
     expect(entryPointCommand).toBeDefined();
     
     // アクションを実行
@@ -79,7 +79,7 @@ describe('useQuickCommands', () => {
   
   test('Market Newsコマンドのアクションが正しく動作すること', () => {
     // Market Newsコマンドを見つける
-    const marketNewsCommand = mockQuickCommands.find(cmd => cmd.label === 'Market News');
+    const marketNewsCommand = MockQuickCommands.find(cmd => cmd.label === 'Market News');
     expect(marketNewsCommand).toBeDefined();
     
     // アクションを実行
@@ -91,7 +91,7 @@ describe('useQuickCommands', () => {
   
   test('AI Signalコマンドのアクションが正しく動作すること', () => {
     // AI Signalコマンドを見つける
-    const aiSignalCommand = mockQuickCommands.find(cmd => cmd.label === 'AI Signal');
+    const aiSignalCommand = MockQuickCommands.find(cmd => cmd.label === 'AI Signal');
     expect(aiSignalCommand).toBeDefined();
     
     // アクションを実行

--- a/__tests__/services/api/bitget/client.test.ts
+++ b/__tests__/services/api/bitget/client.test.ts
@@ -7,20 +7,20 @@ import { BitgetApiClient } from '../../../../services/api/bitget/client';
 import { OHLCData } from '../../../../types/chart';
 
 // モック設定
-const mock = new MockAdapter(axios);
-const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation();
-const mockConsoleError = jest.spyOn(console, 'error').mockImplementation();
+const AxiosMock = new MockAdapter(axios);
+const MockConsoleLog = jest.spyOn(console, 'log').mockImplementation();
+const MockConsoleError = jest.spyOn(console, 'error').mockImplementation();
 
 describe('BitgetApiClient', () => {
   beforeEach(() => {
-    mock.reset();
+    AxiosMock.reset();
     jest.clearAllMocks();
   });
 
   afterAll(() => {
-    mock.restore();
-    mockConsoleLog.mockRestore();
-    mockConsoleError.mockRestore();
+    AxiosMock.restore();
+    MockConsoleLog.mockRestore();
+    MockConsoleError.mockRestore();
   });
 
   describe('fetchCandles', () => {
@@ -32,7 +32,7 @@ describe('BitgetApiClient', () => {
       ];
       
       // モックの設定
-      mock.onGet().reply(200, mockResponse);
+      AxiosMock.onGet().reply(200, mockResponse);
       
       // BitgetApiClientのインスタンス作成
       const client = new BitgetApiClient({}, 'spot');
@@ -59,7 +59,7 @@ describe('BitgetApiClient', () => {
       ];
       
       // モックの設定
-      mock.onGet().reply(200, mockResponse);
+      AxiosMock.onGet().reply(200, mockResponse);
       
       // BitgetApiClientのインスタンス作成
       const client = new BitgetApiClient({}, 'futures');
@@ -80,7 +80,7 @@ describe('BitgetApiClient', () => {
     
     it('エラー時にデモモードが有効な場合はデモデータを返すこと', async () => {
       // モックの設定（エラーを返す）
-      mock.onGet().reply(500);
+      AxiosMock.onGet().reply(500);
       
       // BitgetApiClientのインスタンス作成（デモモード有効）
       const client = new BitgetApiClient({
@@ -104,7 +104,7 @@ describe('BitgetApiClient', () => {
     
     it('エラー時にデモモードが無効な場合はエラーを投げること', async () => {
       // モックの設定（エラーを返す）
-      mock.onGet().reply(500);
+      AxiosMock.onGet().reply(500);
       
       // BitgetApiClientのインスタンス作成（デモモード無効）
       const client = new BitgetApiClient({
@@ -133,7 +133,7 @@ describe('BitgetApiClient', () => {
       };
       
       // モックの設定
-      mock.onGet().reply(200, mockResponse);
+      AxiosMock.onGet().reply(200, mockResponse);
       
       // BitgetApiClientのインスタンス作成
       const client = new BitgetApiClient({}, 'spot');
@@ -186,7 +186,7 @@ describe('BitgetApiClient', () => {
       };
       
       // モックの設定
-      mock.onGet().reply(200, mockResponse);
+      AxiosMock.onGet().reply(200, mockResponse);
       
       // BitgetApiClientのインスタンス作成
       const client = new BitgetApiClient({}, 'futures');
@@ -221,7 +221,7 @@ describe('BitgetApiClient', () => {
     
     it('エラー時にデモモードが有効な場合はデモデータを返すこと', async () => {
       // モックの設定（エラーを返す）
-      mock.onGet().reply(500);
+      AxiosMock.onGet().reply(500);
       
       // BitgetApiClientのインスタンス作成（デモモード有効）
       const client = new BitgetApiClient({
@@ -240,7 +240,7 @@ describe('BitgetApiClient', () => {
     
     it('エラー時にデモモードが無効な場合はエラーを投げること', async () => {
       // モックの設定（エラーを返す）
-      mock.onGet().reply(500);
+      AxiosMock.onGet().reply(500);
       
       // BitgetApiClientのインスタンス作成（デモモード無効）
       const client = new BitgetApiClient({

--- a/__tests__/services/api/bitget/rest-client.test.ts
+++ b/__tests__/services/api/bitget/rest-client.test.ts
@@ -12,7 +12,7 @@ import { BitgetRestClient } from '../../../../services/api/bitget/rest-client';
 import { logger } from '../../../../utils/logger';
 
 // モックの設定
-const mock = new MockAdapter(axios);
+const AxiosMock = new MockAdapter(axios);
 jest.mock('../../../../utils/logger', () => ({
   logger: {
     debug: jest.fn(),
@@ -23,12 +23,12 @@ jest.mock('../../../../utils/logger', () => ({
 
 describe('BitgetRestClient', () => {
   beforeEach(() => {
-    mock.reset();
+    AxiosMock.reset();
     jest.clearAllMocks();
   });
 
   afterAll(() => {
-    mock.restore();
+    AxiosMock.restore();
   });
 
   describe('fetchCandles', () => {
@@ -44,7 +44,7 @@ describe('BitgetRestClient', () => {
       };
       
       // モックの設定
-      mock.onGet().reply(200, mockResponse);
+      AxiosMock.onGet().reply(200, mockResponse);
       
       // インスタンス作成
       const client = new BitgetRestClient();
@@ -74,7 +74,7 @@ describe('BitgetRestClient', () => {
       };
       
       // モックの設定
-      mock.onGet().reply(200, mockResponse);
+      AxiosMock.onGet().reply(200, mockResponse);
       
       // インスタンス作成
       const client = new BitgetRestClient();
@@ -92,8 +92,8 @@ describe('BitgetRestClient', () => {
       expect(result[0]).toHaveProperty('volume', 100);
       
       // 適切なエンドポイントとパラメータが使用されたか確認
-      expect(mock.history.get[0].url).toContain('/api/v2/mix/market/candles');
-      expect(mock.history.get[0].params).toHaveProperty('productType', 'usdt-futures');
+      expect(AxiosMock.history.get[0].url).toContain('/api/v2/mix/market/candles');
+      expect(AxiosMock.history.get[0].params).toHaveProperty('productType', 'usdt-futures');
     });
 
     it('endTimeパラメータが正しく送信されること', async () => {
@@ -107,7 +107,7 @@ describe('BitgetRestClient', () => {
       };
       
       // モックの設定
-      mock.onGet().reply(200, mockResponse);
+      AxiosMock.onGet().reply(200, mockResponse);
       
       // インスタンス作成
       const client = new BitgetRestClient();
@@ -117,7 +117,7 @@ describe('BitgetRestClient', () => {
       await client.fetchCandles('BTC/USDT', '1d', 1, 'spot', endTime);
       
       // リクエストパラメータにendTimeが含まれているか確認
-      expect(mock.history.get[0].params).toHaveProperty('endTime', endTime.toString());
+      expect(AxiosMock.history.get[0].params).toHaveProperty('endTime', endTime.toString());
     });
 
     it('APIエラー時に適切にエラーがスローされること', async () => {
@@ -128,7 +128,7 @@ describe('BitgetRestClient', () => {
       };
       
       // モックの設定
-      mock.onGet().reply(200, mockResponse);
+      AxiosMock.onGet().reply(200, mockResponse);
       
       // インスタンス作成
       const client = new BitgetRestClient();
@@ -142,7 +142,7 @@ describe('BitgetRestClient', () => {
 
     it('ネットワークエラー時に適切にエラーがスローされること', async () => {
       // ネットワークエラーの設定
-      mock.onGet().networkError();
+      AxiosMock.onGet().networkError();
       
       // インスタンス作成
       const client = new BitgetRestClient();
@@ -160,13 +160,13 @@ describe('BitgetRestClient', () => {
         msg: 'success'
       };
       
-      mock.onGet().reply(200, mockResponse);
+      AxiosMock.onGet().reply(200, mockResponse);
       
       const client = new BitgetRestClient();
       await client.fetchCandles('BTC/USDT', '1d', 1);
       
       // パラメータでシンボルが正規化されているか確認
-      expect(mock.history.get[0].params.symbol).toBe('BTCUSDT');
+      expect(AxiosMock.history.get[0].params.symbol).toBe('BTCUSDT');
     });
 
     it('タイムフレームが正しく変換されること', async () => {
@@ -176,19 +176,19 @@ describe('BitgetRestClient', () => {
         msg: 'success'
       };
       
-      mock.onGet().reply(200, mockResponse);
+      AxiosMock.onGet().reply(200, mockResponse);
       
       const client = new BitgetRestClient();
       
       // 先物取引で時間足形式が大文字になることを確認 (1h -> 1H)
       await client.fetchCandles('BTC/USDT', '1h', 1, 'futures');
-      expect(mock.history.get[0].params.granularity).toBe('1H');
+      expect(AxiosMock.history.get[0].params.granularity).toBe('1H');
       
       // スポット取引で時間足形式が適切に変換されることを確認
-      mock.resetHistory();
-      mock.onGet().reply(200, mockResponse);
+      AxiosMock.resetHistory();
+      AxiosMock.onGet().reply(200, mockResponse);
       await client.fetchCandles('BTC/USDT', '1h', 1, 'spot');
-      expect(mock.history.get[0].params.granularity).toBe('1h');
+      expect(AxiosMock.history.get[0].params.granularity).toBe('1h');
     });
   });
 
@@ -212,7 +212,7 @@ describe('BitgetRestClient', () => {
       };
       
       // モックの設定
-      mock.onGet().reply(200, mockResponse);
+      AxiosMock.onGet().reply(200, mockResponse);
       
       // インスタンス作成
       const client = new BitgetRestClient();
@@ -250,7 +250,7 @@ describe('BitgetRestClient', () => {
       };
       
       // モックの設定
-      mock.onGet().reply(200, mockResponse);
+      AxiosMock.onGet().reply(200, mockResponse);
       
       // インスタンス作成
       const client = new BitgetRestClient();
@@ -265,8 +265,8 @@ describe('BitgetRestClient', () => {
       expect(result.bids.length).toBe(2);
       
       // 適切なエンドポイントとパラメータが使用されたか確認
-      expect(mock.history.get[0].url).toContain('/api/v2/mix/market/orderbook');
-      expect(mock.history.get[0].params).toHaveProperty('productType', 'usdt-futures');
+      expect(AxiosMock.history.get[0].url).toContain('/api/v2/mix/market/orderbook');
+      expect(AxiosMock.history.get[0].params).toHaveProperty('productType', 'usdt-futures');
     });
 
     it('APIエラー時に適切にエラーがスローされること', async () => {
@@ -277,7 +277,7 @@ describe('BitgetRestClient', () => {
       };
       
       // モックの設定
-      mock.onGet().reply(200, mockResponse);
+      AxiosMock.onGet().reply(200, mockResponse);
       
       // インスタンス作成
       const client = new BitgetRestClient();
@@ -291,7 +291,7 @@ describe('BitgetRestClient', () => {
 
     it('ネットワークエラー時に適切にエラーがスローされること', async () => {
       // ネットワークエラーの設定
-      mock.onGet().networkError();
+      AxiosMock.onGet().networkError();
       
       // インスタンス作成
       const client = new BitgetRestClient();
@@ -313,13 +313,13 @@ describe('BitgetRestClient', () => {
         msg: 'success'
       };
       
-      mock.onGet().reply(200, mockResponse);
+      AxiosMock.onGet().reply(200, mockResponse);
       
       const client = new BitgetRestClient();
       await client.fetchOrderBook('ETH/BTC', 1);
       
       // パラメータでシンボルが正規化されているか確認
-      expect(mock.history.get[0].params.symbol).toBe('ETHBTC');
+      expect(AxiosMock.history.get[0].params.symbol).toBe('ETHBTC');
     });
   });
 
@@ -336,7 +336,7 @@ describe('BitgetRestClient', () => {
       };
       
       // モックの設定
-      mock.onGet().reply(200, mockResponse);
+      AxiosMock.onGet().reply(200, mockResponse);
       
       // インスタンス作成
       const client = new BitgetRestClient();
@@ -370,7 +370,7 @@ describe('BitgetRestClient', () => {
       };
       
       // モックの設定
-      mock.onGet().reply(200, mockResponse);
+      AxiosMock.onGet().reply(200, mockResponse);
       
       // インスタンス作成
       const client = new BitgetRestClient();

--- a/__tests__/services/data/chart-data-service.test.ts
+++ b/__tests__/services/data/chart-data-service.test.ts
@@ -33,7 +33,7 @@ jest.mock('../../../services/socket/index');
 jest.mock('../../../utils/logger');
 
 // テスト用のモックデータ
-const mockOHLCData: OHLCData[] = [
+const MockOHLCData: OHLCData[] = [
   {
     time: 1620000000000,
     open: 50000.00,
@@ -62,7 +62,7 @@ describe('ChartDataService', () => {
     
     // BitgetApiClientのモックを設定
     mockBitgetApiClient = new BitgetApiClient() as jest.Mocked<BitgetApiClient>;
-    mockBitgetApiClient.fetchCandles = jest.fn().mockResolvedValue(mockOHLCData);
+    mockBitgetApiClient.fetchCandles = jest.fn().mockResolvedValue(MockOHLCData);
     
     // ChartDataServiceのシングルトンインスタンスをリセット
     resetChartDataServiceForTesting();
@@ -80,7 +80,7 @@ describe('ChartDataService', () => {
       const result = await testChartDataService.fetchChartData('BTC/USDT', '1m', EXCHANGE_TYPES.SPOT);
       
       // 検証
-      expect(result).toEqual(mockOHLCData);
+      expect(result).toEqual(MockOHLCData);
       expect(mockBitgetApiClient.fetchCandles).toHaveBeenCalledWith('BTC/USDT', '1m', 100, PRODUCT_TYPES.SPOT);
       expect(cacheService.set).toHaveBeenCalled();
       expect(logger.info).toHaveBeenCalled();
@@ -91,7 +91,7 @@ describe('ChartDataService', () => {
       const result = await testChartDataService.fetchChartData('BTC/USDT', '1m', EXCHANGE_TYPES.FUTURES);
       
       // 検証
-      expect(result).toEqual(mockOHLCData);
+      expect(result).toEqual(MockOHLCData);
       expect(mockBitgetApiClient.fetchCandles).toHaveBeenCalledWith('BTC/USDT', '1m', 100, PRODUCT_TYPES.FUTURES);
       expect(cacheService.set).toHaveBeenCalled();
       expect(logger.info).toHaveBeenCalled();
@@ -99,13 +99,13 @@ describe('ChartDataService', () => {
     
     it('キャッシュからデータを取得できること', async () => {
       // キャッシュのモックを設定
-      (cacheService.get as jest.Mock).mockReturnValueOnce(mockOHLCData);
+      (cacheService.get as jest.Mock).mockReturnValueOnce(MockOHLCData);
       
       // テスト実行
       const result = await testChartDataService.fetchChartData('BTC/USDT', '1m', EXCHANGE_TYPES.SPOT, undefined, true);
       
       // 検証
-      expect(result).toEqual(mockOHLCData);
+      expect(result).toEqual(MockOHLCData);
       expect(cacheService.get).toHaveBeenCalled();
       expect(mockBitgetApiClient.fetchCandles).not.toHaveBeenCalled();
       expect(logger.debug).toHaveBeenCalled();

--- a/__tests__/services/socket/socket-service.test.ts
+++ b/__tests__/services/socket/socket-service.test.ts
@@ -15,7 +15,7 @@ import { BitgetApiClient } from '../../../services/api/bitget/client';
 import { logger } from '../../../utils/logger';
 
 // モック
-const mockSocket = {
+const MockSocket = {
   on: jest.fn(),
   off: jest.fn(),
   emit: jest.fn(),
@@ -23,16 +23,16 @@ const mockSocket = {
 };
 
 // WebSocketClientモック
-const mockWebSocketClient: IWebSocketClient = {
-  initialize: jest.fn().mockReturnValue(mockSocket),
-  getSocket: jest.fn().mockReturnValue(mockSocket),
+const MockWebSocketClient: IWebSocketClient = {
+  initialize: jest.fn().mockReturnValue(MockSocket),
+  getSocket: jest.fn().mockReturnValue(MockSocket),
   isConnected: jest.fn().mockReturnValue(true),
   disconnect: jest.fn(),
   scheduleReconnect: jest.fn()
 };
 
 // SubscriptionManagerモック
-const mockSubscriptionManager: ISubscriptionManager = {
+const MockSubscriptionManager: ISubscriptionManager = {
   subscribeOrderBook: jest.fn().mockReturnValue(() => {}),
   subscribeKline: jest.fn().mockReturnValue(() => {}),
   subscribeTrades: jest.fn().mockReturnValue(() => {}),
@@ -41,7 +41,7 @@ const mockSubscriptionManager: ISubscriptionManager = {
 };
 
 // BitgetApiClientモック
-const mockBitgetApiClient = {
+const MockBitgetApiClient = {
   disconnectWebSocket: jest.fn(),
   fetchCandles: jest.fn(),
   fetchOrderBook: jest.fn(),
@@ -50,9 +50,9 @@ const mockBitgetApiClient = {
 };
 
 // BitgetIntegrationモック
-const mockBitgetIntegration: IBitgetIntegration = {
-  initializeApiClient: jest.fn().mockReturnValue(mockBitgetApiClient),
-  getCurrentApiClient: jest.fn().mockReturnValue(mockBitgetApiClient),
+const MockBitgetIntegration: IBitgetIntegration = {
+  initializeApiClient: jest.fn().mockReturnValue(MockBitgetApiClient),
+  getCurrentApiClient: jest.fn().mockReturnValue(MockBitgetApiClient),
   disconnectApiClient: jest.fn()
 };
 
@@ -73,9 +73,9 @@ describe('SocketService', () => {
     
     // SocketServiceインスタンスを作成
     socketService = new SocketService(
-      mockWebSocketClient,
-      mockSubscriptionManager,
-      mockBitgetIntegration
+      MockWebSocketClient,
+      MockSubscriptionManager,
+      MockBitgetIntegration
     );
   });
   
@@ -98,8 +98,8 @@ describe('SocketService', () => {
       const result = socketService.initializeMarketSocket();
       
       // 結果を検証
-      expect(mockWebSocketClient.initialize).toHaveBeenCalled();
-      expect(result).toBe(mockSocket);
+      expect(MockWebSocketClient.initialize).toHaveBeenCalled();
+      expect(result).toBe(MockSocket);
     });
   });
   
@@ -109,8 +109,8 @@ describe('SocketService', () => {
       const result = socketService.initializeApiClient('spot' as ProductType);
       
       // 結果を検証
-      expect(mockBitgetIntegration.initializeApiClient).toHaveBeenCalledWith('spot', {});
-      expect(result).toBe(mockBitgetApiClient);
+      expect(MockBitgetIntegration.initializeApiClient).toHaveBeenCalledWith('spot', {});
+      expect(result).toBe(MockBitgetApiClient);
     });
     
     it('設定オプションを正しく渡すこと', () => {
@@ -121,7 +121,7 @@ describe('SocketService', () => {
       socketService.initializeApiClient('futures' as ProductType, config);
       
       // 結果を検証
-      expect(mockBitgetIntegration.initializeApiClient).toHaveBeenCalledWith('futures', config);
+      expect(MockBitgetIntegration.initializeApiClient).toHaveBeenCalledWith('futures', config);
     });
   });
   
@@ -131,8 +131,8 @@ describe('SocketService', () => {
       const result = socketService.getCurrentApiClient();
       
       // 結果を検証
-      expect(mockBitgetIntegration.getCurrentApiClient).toHaveBeenCalled();
-      expect(result).toBe(mockBitgetApiClient);
+      expect(MockBitgetIntegration.getCurrentApiClient).toHaveBeenCalled();
+      expect(result).toBe(MockBitgetApiClient);
     });
   });
   
@@ -145,7 +145,7 @@ describe('SocketService', () => {
       const unsubscribe = socketService.subscribeOrderBook('BTC/USDT', callback);
       
       // 結果を検証
-      expect(mockSubscriptionManager.subscribeOrderBook).toHaveBeenCalledWith(
+      expect(MockSubscriptionManager.subscribeOrderBook).toHaveBeenCalledWith(
         'BTC/USDT',
         callback,
         'spot'
@@ -161,7 +161,7 @@ describe('SocketService', () => {
       socketService.subscribeOrderBook('BTC/USDT', callback, 'futures' as ProductType);
       
       // 結果を検証
-      expect(mockSubscriptionManager.subscribeOrderBook).toHaveBeenCalledWith(
+      expect(MockSubscriptionManager.subscribeOrderBook).toHaveBeenCalledWith(
         'BTC/USDT',
         callback,
         'futures'
@@ -178,7 +178,7 @@ describe('SocketService', () => {
       const unsubscribe = socketService.subscribeKline('BTC/USDT', '1m', callback);
       
       // 結果を検証
-      expect(mockSubscriptionManager.subscribeKline).toHaveBeenCalledWith(
+      expect(MockSubscriptionManager.subscribeKline).toHaveBeenCalledWith(
         'BTC/USDT',
         '1m',
         callback,
@@ -195,7 +195,7 @@ describe('SocketService', () => {
       socketService.subscribeKline('BTC/USDT', '1m', callback, 'futures' as ProductType);
       
       // 結果を検証
-      expect(mockSubscriptionManager.subscribeKline).toHaveBeenCalledWith(
+      expect(MockSubscriptionManager.subscribeKline).toHaveBeenCalledWith(
         'BTC/USDT',
         '1m',
         callback,
@@ -210,8 +210,8 @@ describe('SocketService', () => {
       socketService.disconnectAll();
       
       // 結果を検証
-      expect(mockWebSocketClient.disconnect).toHaveBeenCalled();
-      expect(mockBitgetIntegration.disconnectApiClient).toHaveBeenCalled();
+      expect(MockWebSocketClient.disconnect).toHaveBeenCalled();
+      expect(MockBitgetIntegration.disconnectApiClient).toHaveBeenCalled();
       expect(logger.info).toHaveBeenCalledWith(
         'すべての接続を切断しました',
         expect.objectContaining({
@@ -223,7 +223,7 @@ describe('SocketService', () => {
     
     it('切断中にエラーが発生した場合はログを出力すること', () => {
       // disconnectでエラーを発生させる
-      (mockWebSocketClient.disconnect as jest.Mock).mockImplementation(() => {
+      (MockWebSocketClient.disconnect as jest.Mock).mockImplementation(() => {
         throw new Error('切断エラー');
       });
       
@@ -249,7 +249,7 @@ describe('SocketService', () => {
       socketService.scheduleReconnect();
       
       // 結果を検証
-      expect(mockWebSocketClient.scheduleReconnect).toHaveBeenCalled();
+      expect(MockWebSocketClient.scheduleReconnect).toHaveBeenCalled();
     });
   });
   
@@ -259,7 +259,7 @@ describe('SocketService', () => {
       socketService.resubscribeAll();
       
       // 結果を検証
-      expect(mockSubscriptionManager.resubscribeAll).toHaveBeenCalled();
+      expect(MockSubscriptionManager.resubscribeAll).toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/services/socket/subscription-manager.test.ts
+++ b/__tests__/services/socket/subscription-manager.test.ts
@@ -32,7 +32,7 @@ jest.mock('../../../utils/logger', () => ({
 const { logger } = require('../../../utils/logger');
 
 // モック
-const mockSocket = {
+const MockSocket = {
   on: jest.fn(),
   off: jest.fn(),
   emit: jest.fn(),
@@ -40,9 +40,9 @@ const mockSocket = {
 };
 
 // WebSocketClientモック
-const mockWebSocketClient: IWebSocketClient = {
+const MockWebSocketClient: IWebSocketClient = {
   initialize: jest.fn(),
-  getSocket: jest.fn().mockReturnValue(mockSocket),
+  getSocket: jest.fn().mockReturnValue(MockSocket),
   isConnected: jest.fn().mockReturnValue(true),
   disconnect: jest.fn(),
   scheduleReconnect: jest.fn()
@@ -64,13 +64,13 @@ describe('SubscriptionManager', () => {
     jest.clearAllMocks();
     
     // SubscriptionManagerインスタンスを作成
-    subscriptionManager = new SubscriptionManager(mockWebSocketClient);
+    subscriptionManager = new SubscriptionManager(MockWebSocketClient);
   });
   
   describe('subscribeOrderBook', () => {
     it('ソケットが初期化されていない場合は空の関数を返すこと', () => {
       // getSocketの戻り値をnullに設定
-      (mockWebSocketClient.getSocket as jest.Mock).mockReturnValueOnce(null);
+      (MockWebSocketClient.getSocket as jest.Mock).mockReturnValueOnce(null);
       
       // subscribeOrderBookを実行
       const unsubscribe = subscriptionManager.subscribeOrderBook('BTC/USDT', jest.fn());
@@ -110,21 +110,21 @@ describe('SubscriptionManager', () => {
       };
       
       // ハンドラを実行
-      const subManager = new SubscriptionManager(mockWebSocketClient);
+      const subManager = new SubscriptionManager(MockWebSocketClient);
       const unsubscribe = subManager.subscribeOrderBook(symbol, callback, exchangeType);
       
       // emitが正しく呼ばれたことを確認
-      expect(mockSocket.emit).toHaveBeenCalledWith('subscribe', {
+      expect(MockSocket.emit).toHaveBeenCalledWith('subscribe', {
         symbol: 'BTCUSDT',
         type: 'orderbook',
         exchangeType: 'spot'
       });
       
       // 適切なイベントリスナが登録されたことを確認
-      expect(mockSocket.on).toHaveBeenCalledWith('orderbook', expect.any(Function));
+      expect(MockSocket.on).toHaveBeenCalledWith('orderbook', expect.any(Function));
       
       // イベントハンドラを取得
-      const handler = mockSocket.on.mock.calls.find(
+      const handler = MockSocket.on.mock.calls.find(
         (call) => call[0] === 'orderbook'
       )[1];
       
@@ -143,7 +143,7 @@ describe('SubscriptionManager', () => {
       unsubscribe();
       
       // emitが正しく呼ばれたことを確認
-      expect(mockSocket.emit).toHaveBeenCalledWith('unsubscribe', {
+      expect(MockSocket.emit).toHaveBeenCalledWith('unsubscribe', {
         symbol: 'BTCUSDT',
         type: 'orderbook',
         exchangeType: 'spot'
@@ -151,8 +151,8 @@ describe('SubscriptionManager', () => {
     });
     
     it('購読中にエラーが発生した場合はログを出力すること', () => {
-      // mockSocket.emitでエラーを発生させる
-      mockSocket.emit.mockImplementationOnce(() => {
+      // MockSocket.emitでエラーを発生させる
+      MockSocket.emit.mockImplementationOnce(() => {
         throw new Error('購読エラー');
       });
       
@@ -178,7 +178,7 @@ describe('SubscriptionManager', () => {
   describe('subscribeKline', () => {
     it('ソケットが初期化されていない場合は空の関数を返すこと', () => {
       // getSocketの戻り値をnullに設定
-      (mockWebSocketClient.getSocket as jest.Mock).mockReturnValueOnce(null);
+      (MockWebSocketClient.getSocket as jest.Mock).mockReturnValueOnce(null);
       
       // subscribeKlineを実行
       const unsubscribe = subscriptionManager.subscribeKline('BTC/USDT', '1m', jest.fn());
@@ -217,11 +217,11 @@ describe('SubscriptionManager', () => {
       };
       
       // ハンドラを実行
-      const subManager = new SubscriptionManager(mockWebSocketClient);
+      const subManager = new SubscriptionManager(MockWebSocketClient);
       const unsubscribe = subManager.subscribeKline(symbol, timeframe, callback, exchangeType);
       
       // emitが正しく呼ばれたことを確認
-      expect(mockSocket.emit).toHaveBeenCalledWith('subscribe', {
+      expect(MockSocket.emit).toHaveBeenCalledWith('subscribe', {
         symbol: 'BTCUSDT',
         type: 'kline',
         timeframe: '1m',
@@ -229,10 +229,10 @@ describe('SubscriptionManager', () => {
       });
       
       // 適切なイベントリスナが登録されたことを確認
-      expect(mockSocket.on).toHaveBeenCalledWith('kline', expect.any(Function));
+      expect(MockSocket.on).toHaveBeenCalledWith('kline', expect.any(Function));
       
       // イベントハンドラを取得
-      const handler = mockSocket.on.mock.calls.find(
+      const handler = MockSocket.on.mock.calls.find(
         (call) => call[0] === 'kline'
       )[1];
       
@@ -253,7 +253,7 @@ describe('SubscriptionManager', () => {
       unsubscribe();
       
       // emitが正しく呼ばれたことを確認
-      expect(mockSocket.emit).toHaveBeenCalledWith('unsubscribe', {
+      expect(MockSocket.emit).toHaveBeenCalledWith('unsubscribe', {
         symbol: 'BTCUSDT',
         type: 'kline',
         timeframe: '1m',
@@ -269,15 +269,15 @@ describe('SubscriptionManager', () => {
       subscriptionManager.subscribeKline('BTC/USDT', '1m', jest.fn());
       
       // モックをリセット
-      mockSocket.off.mockClear();
-      mockSocket.emit.mockClear();
+      MockSocket.off.mockClear();
+      MockSocket.emit.mockClear();
       
       // unsubscribeAllを実行
       subscriptionManager.unsubscribeAll();
       
       // 結果を検証
-      expect(mockSocket.off).toHaveBeenCalledTimes(2);
-      expect(mockSocket.emit).toHaveBeenCalledTimes(2);
+      expect(MockSocket.off).toHaveBeenCalledTimes(2);
+      expect(MockSocket.emit).toHaveBeenCalledTimes(2);
       expect(logger.info).toHaveBeenCalledWith(
         'すべての購読を解除しました',
         expect.objectContaining({
@@ -289,7 +289,7 @@ describe('SubscriptionManager', () => {
     
     it('ソケットが初期化されていない場合はログを出力すること', () => {
       // getSocketの戻り値をnullに設定
-      (mockWebSocketClient.getSocket as jest.Mock).mockReturnValueOnce(null);
+      (MockWebSocketClient.getSocket as jest.Mock).mockReturnValueOnce(null);
       
       // unsubscribeAllを実行
       subscriptionManager.unsubscribeAll();
@@ -312,15 +312,15 @@ describe('SubscriptionManager', () => {
       subscriptionManager.subscribeKline('BTC/USDT', '1m', jest.fn());
       
       // モックをリセット
-      mockSocket.on.mockClear();
-      mockSocket.emit.mockClear();
+      MockSocket.on.mockClear();
+      MockSocket.emit.mockClear();
       
       // resubscribeAllを実行
       subscriptionManager.resubscribeAll();
       
       // 結果を検証
-      expect(mockSocket.on).toHaveBeenCalledTimes(2);
-      expect(mockSocket.emit).toHaveBeenCalledTimes(4); // unsubscribe + subscribe
+      expect(MockSocket.on).toHaveBeenCalledTimes(2);
+      expect(MockSocket.emit).toHaveBeenCalledTimes(4); // unsubscribe + subscribe
       expect(logger.info).toHaveBeenCalledWith(
         'すべての購読を再購読しました',
         expect.objectContaining({
@@ -333,7 +333,7 @@ describe('SubscriptionManager', () => {
     
     it('ソケットが初期化されていない場合はログを出力すること', () => {
       // getSocketの戻り値をnullに設定
-      (mockWebSocketClient.getSocket as jest.Mock).mockReturnValueOnce(null);
+      (MockWebSocketClient.getSocket as jest.Mock).mockReturnValueOnce(null);
       
       // resubscribeAllを実行
       subscriptionManager.resubscribeAll();

--- a/__tests__/services/socket/websocket-client.test.ts
+++ b/__tests__/services/socket/websocket-client.test.ts
@@ -34,7 +34,7 @@ jest.mock('../../../utils/logger', () => {
 });
 
 // モックソケットインスタンス
-const mockSocket = {
+const MockSocket = {
   connected: true,
   id: 'mock-socket-id',
   on: jest.fn(),
@@ -50,7 +50,7 @@ describe('WebSocketClient', () => {
     jest.clearAllMocks();
     
     // SocketCoreのモック設定
-    (SocketCore.getSocket as jest.Mock).mockReturnValue(mockSocket);
+    (SocketCore.getSocket as jest.Mock).mockReturnValue(MockSocket);
     (SocketCore.getConnectionStatus as jest.Mock).mockReturnValue({ 
       connected: true, 
       id: 'mock-socket-id' 
@@ -93,15 +93,15 @@ describe('WebSocketClient', () => {
       const result = webSocketClient.initialize();
       
       // 結果を検証
-      expect(result).toBe(mockSocket);
+      expect(result).toBe(MockSocket);
       expect(SocketCore.getSocket).toHaveBeenCalledWith(true);
       expect(logger.info).toHaveBeenCalledWith(
         'WebSocketClient: Socket.IO接続を初期化しました',
         expect.objectContaining({
           component: 'WebSocketClient',
           action: 'initialize',
-          connected: mockSocket.connected,
-          id: mockSocket.id
+          connected: MockSocket.connected,
+          id: MockSocket.id
         })
       );
     });
@@ -118,7 +118,7 @@ describe('WebSocketClient', () => {
       expect(result).toBeNull();
       
       // 元のモックに戻す
-      (SocketCore.getSocket as jest.Mock).mockReturnValue(mockSocket);
+      (SocketCore.getSocket as jest.Mock).mockReturnValue(MockSocket);
     });
   });
   
@@ -128,7 +128,7 @@ describe('WebSocketClient', () => {
       const result = webSocketClient.getSocket();
       
       // 結果を検証
-      expect(result).toBe(mockSocket);
+      expect(result).toBe(MockSocket);
       expect(SocketCore.getSocket).toHaveBeenCalledWith(false);
     });
   });

--- a/__tests__/unit/store/socketActions.test.ts
+++ b/__tests__/unit/store/socketActions.test.ts
@@ -5,16 +5,16 @@
 import { logger } from '../../../utils/logger';
 
 // 各ドメインストアをモック化
-const mockSetCurrentSymbol = jest.fn();
-const mockSetExchangeType = jest.fn();
-const mockUpdateTimeFrame = jest.fn();
+const MockSetCurrentSymbol = jest.fn();
+const MockSetExchangeType = jest.fn();
+const MockUpdateTimeFrame = jest.fn();
 
 // useSymbolStoreのモック
 jest.mock('../../../store/useSymbolStore', () => ({
   useSymbolStore: {
     getState: jest.fn().mockReturnValue({
-      setCurrentSymbol: mockSetCurrentSymbol,
-      setProductType: mockSetExchangeType,
+      setCurrentSymbol: MockSetCurrentSymbol,
+      setProductType: MockSetExchangeType,
       currentSymbol: 'BTCUSDT',
       exchangeType: 'spot',
     }),
@@ -25,7 +25,7 @@ jest.mock('../../../store/useSymbolStore', () => ({
 jest.mock('../../../store/chart', () => ({
   useChartDataStore: {
     getState: jest.fn().mockReturnValue({
-      updateTimeFrame: mockUpdateTimeFrame,
+      updateTimeFrame: MockUpdateTimeFrame,
       currentTimeFrame: '1d',
     }),
   },
@@ -64,7 +64,7 @@ describe('socketStoreActions', () => {
       socketActions.setSymbol('ETHUSDT', 'test-source');
       
       // AppStore.setCurrentSymbol が正しく呼ばれたか検証
-      expect(mockSetCurrentSymbol).toHaveBeenCalledWith(
+      expect(MockSetCurrentSymbol).toHaveBeenCalledWith(
         'ETHUSDT',
         'test-source'
       );
@@ -92,7 +92,7 @@ describe('socketStoreActions', () => {
     it('エラー時に適切にログを出力すること', () => {
       // setCurrentSymbol でエラーが発生するようにモック
       const error = new Error('テストエラー');
-      mockSetCurrentSymbol.mockImplementation(() => {
+      MockSetCurrentSymbol.mockImplementation(() => {
         throw error;
       });
       
@@ -119,7 +119,7 @@ describe('socketStoreActions', () => {
       socketActions.setProductType('futures', 'BTCUSDT', 'test-source');
       
       // AppStore.setProductType が正しく呼ばれたか検証
-      expect(mockSetExchangeType).toHaveBeenCalledWith(
+      expect(MockSetExchangeType).toHaveBeenCalledWith(
         'futures'
       );
       
@@ -138,7 +138,7 @@ describe('socketStoreActions', () => {
     it('エラー時に適切にログを出力すること', () => {
       // setProductType でエラーが発生するようにモック
       const error = new Error('テストエラー');
-      mockSetExchangeType.mockImplementation(() => {
+      MockSetExchangeType.mockImplementation(() => {
         throw error;
       });
       
@@ -166,7 +166,7 @@ describe('socketStoreActions', () => {
       socketActions.setTimeframe('4h', 'test-source');
       
       // AppStore.updateTimeFrame が正しく呼ばれたか検証
-      expect(mockUpdateTimeFrame).toHaveBeenCalledWith(
+      expect(MockUpdateTimeFrame).toHaveBeenCalledWith(
         '4h'
       );
       
@@ -193,7 +193,7 @@ describe('socketStoreActions', () => {
     it('エラー時に適切にログを出力すること', () => {
       // updateTimeFrame でエラーが発生するようにモック
       const error = new Error('テストエラー');
-      mockUpdateTimeFrame.mockImplementation(() => {
+      MockUpdateTimeFrame.mockImplementation(() => {
         throw error;
       });
       

--- a/__tests__/unit/supabase-entry.test.ts
+++ b/__tests__/unit/supabase-entry.test.ts
@@ -8,7 +8,7 @@ import { Tables } from '@/types/network/supabase';
 
 // Supabaseのモジュールをモック
 jest.mock('@/lib/supabase/supabase', () => {
-  const mockChannel = {
+  const MockChannel = {
     on: jest.fn().mockReturnThis(),
     subscribe: jest.fn().mockImplementation((callback) => {
       if (callback) callback('SUBSCRIBED');
@@ -16,7 +16,7 @@ jest.mock('@/lib/supabase/supabase', () => {
     }),
   };
 
-  const mockSelect = {
+  const MockSelect = {
     eq: jest.fn().mockReturnThis(),
     order: jest.fn().mockReturnThis(),
     range: jest.fn().mockReturnThis(),
@@ -26,30 +26,30 @@ jest.mock('@/lib/supabase/supabase', () => {
     in: jest.fn().mockReturnThis(),
   };
 
-  const mockInsert = {
+  const MockInsert = {
     select: jest.fn().mockReturnThis(),
     single: jest.fn().mockReturnThis(),
   };
 
-  const mockUpdate = {
+  const MockUpdate = {
     eq: jest.fn().mockReturnThis(),
     select: jest.fn().mockReturnThis(),
     single: jest.fn().mockReturnThis(),
   };
 
-  const mockDelete = {
+  const MockDelete = {
     eq: jest.fn().mockReturnThis(),
   };
 
   return {
     supabase: {
       from: jest.fn().mockImplementation(() => ({
-        select: jest.fn().mockReturnValue(mockSelect),
-        insert: jest.fn().mockReturnValue(mockInsert),
-        update: jest.fn().mockReturnValue(mockUpdate),
-        delete: jest.fn().mockReturnValue(mockDelete),
+        select: jest.fn().mockReturnValue(MockSelect),
+        insert: jest.fn().mockReturnValue(MockInsert),
+        update: jest.fn().mockReturnValue(MockUpdate),
+        delete: jest.fn().mockReturnValue(MockDelete),
       })),
-      channel: jest.fn().mockReturnValue(mockChannel),
+      channel: jest.fn().mockReturnValue(MockChannel),
       removeChannel: jest.fn(),
     }
   };

--- a/types/chart.ts
+++ b/types/chart.ts
@@ -39,7 +39,7 @@ export interface BusinessDay {
  * Time 型（lightweight-charts の型定義から）
  * チャートの時間軸で使用される型
  */
-export type Time = UTCTimestamp | BusinessDay | string;
+export type Time = UTCTimestamp | BusinessDay;
 
 /**
  * ChartTimeCompatible 型

--- a/types/chart/time.ts
+++ b/types/chart/time.ts
@@ -34,7 +34,7 @@ export interface BusinessDay {
  * Time 型（lightweight-charts の型定義から）
  * チャートの時間軸で使用される型
  */
-export type Time = UTCTimestamp | BusinessDay | string;
+export type Time = UTCTimestamp | BusinessDay;
 
 /**
  * ChartTimeCompatible 型


### PR DESCRIPTION
## Summary
- tighten Time type for lightweight-charts v5
- rename various test constants from camelCase to PascalCase

## Testing
- `npm run typecheck:test` *(fails: Cannot find type definition file for 'jest')*
- `npm test` *(fails during typecheck step)*