### PR TITLE
Extend useLogs hook

### DIFF
--- a/hooks/debug/logs/useLogs.ts
+++ b/hooks/debug/logs/useLogs.ts
@@ -1,5 +1,10 @@
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import { getStoredLogs, clearStoredLogs, type StoredLog } from '@/utils/logStorage';
 
+// ログタブで選択できるレベル
+export type LogLevel = 'all' | 'error' | 'warn' | 'debug';
+
+// 旧インターフェースとの互換のために残している型
 export interface LogEntry {
   message: string;
   timestamp: number;
@@ -10,27 +15,31 @@ export interface LogEntry {
 /**
  * デバッグログを管理するフック
  */
-export function useLogs() {
-  const [logs, setLogs] = useState<LogEntry[]>([]);
-  
-  const addLog = (entry: Omit<LogEntry, 'timestamp'>) => {
-    setLogs(prev => [
-      ...prev,
-      {
-        ...entry,
-        timestamp: Date.now()
-      }
-    ]);
-  };
-  
-  const clearLogs = () => {
+export function useLogs(activeTab: LogLevel = 'all') {
+  const [logs, setLogs] = useState<StoredLog[]>([]);
+
+  const refreshLogs = useCallback(() => {
+    const stored = getStoredLogs();
+    const filtered =
+      activeTab === 'all'
+        ? stored
+        : stored.filter((log) => log.level === activeTab);
+    setLogs(filtered);
+  }, [activeTab]);
+
+  const handleClearLogs = useCallback(() => {
+    clearStoredLogs();
     setLogs([]);
-  };
-  
+  }, []);
+
+  useEffect(() => {
+    refreshLogs();
+  }, [refreshLogs]);
+
   return {
     logs,
-    addLog,
-    clearLogs
+    refreshLogs,
+    handleClearLogs
   };
 }
 


### PR DESCRIPTION
## Summary
- expand useLogs hook API to match latest tests
- add LogLevel type, refreshLogs and handleClearLogs utilities

## Testing
- `npm test` *(fails: Cannot find type definition file for 'jest')*