### PR TITLE
Fix store imports in tests

### DIFF
--- a/__tests__/chart/useChartSectionInit.test.ts
+++ b/__tests__/chart/useChartSectionInit.test.ts
@@ -15,7 +15,7 @@ import { type ExchangeType } from '@/types/constants/enums';
 import { safeExchangeType } from '@/utils/exchangeTypeUtils';
 
 // ストアをモック
-jest.mock('@/store/useSymbolStore', () => ({
+jest.mock('@/store/symbol', () => ({
   useSymbolStore: {
     getState: jest.fn().mockReturnValue({
       currentSymbol: 'BTCUSDT'
@@ -23,7 +23,7 @@ jest.mock('@/store/useSymbolStore', () => ({
   }
 }));
 
-jest.mock('@/store/chart', () => ({
+jest.mock('@/store/chart/data', () => ({
   useChartDataStore: {
     getState: jest.fn().mockReturnValue({
       currentTimeFrame: '1h'

--- a/__tests__/components/ChartContainer.test.tsx
+++ b/__tests__/components/ChartContainer.test.tsx
@@ -10,17 +10,17 @@
 
 import React from 'react';
 import { render, act } from '@testing-library/react';
-import { ChartContainer } from '../../components/chart/ChartContainer';
-import { useSymbolStore } from '../../store/symbol';
-import { useChartDataStore } from '../../store/chart/data';
-import { logger } from '../../utils/common';
+import { ChartContainer } from '@/components/chart/ChartContainer';
+import { useSymbolStore } from '@/store/symbol';
+import { useChartDataStore } from '@/store/chart/data';
+import { logger } from '@/utils/common';
 
 // モック
-jest.mock('../../store/symbol', () => ({
+jest.mock('@/store/symbol', () => ({
   useSymbolStore: jest.fn()
 }));
 
-jest.mock('../../store/chart', () => ({
+jest.mock('@/store/chart', () => ({
   useChartDataStore: jest.fn(() => ({
     currentTimeFrame: '1h',
     fetchData: jest.fn(),
@@ -47,7 +47,7 @@ jest.mock('../../store/chart', () => ({
   }))
 }));
 
-jest.mock('../../utils/common', () => ({
+jest.mock('@/utils/common', () => ({
   logger: {
     info: jest.fn(),
     warn: jest.fn(),

--- a/__tests__/hooks/symbol/usePopularSymbols.test.ts
+++ b/__tests__/hooks/symbol/usePopularSymbols.test.ts
@@ -5,7 +5,7 @@
 
 import { renderHook } from '@testing-library/react';
 import { usePopularSymbols, POPULAR_SYMBOLS } from '@/hooks/symbol';
-import type { FilterOptions, SymbolInfo } from '@/store/useSymbolStore';
+import type { FilterOptions, SymbolInfo } from '@/types/symbol';
 
 // モックシンボルデータ
 const mockSymbols: SymbolInfo[] = [

--- a/store/index.ts
+++ b/store/index.ts
@@ -65,6 +65,10 @@ export { createDebugSlice } from './debug'
 export { createDataFetchSlice } from './dataFetch'
 export { createSettingsSlice } from './settings'
 
+// Backward compatibility exports
+export { useSymbolStore } from './symbol'
+export { socketStoreActions } from './socketActions'
+
 // セレクター
 export * from './selectors'
 


### PR DESCRIPTION
## Summary
- update test imports to use new store locations
- export `useSymbolStore` and `socketStoreActions` from store barrel for compatibility

## Testing
- `npm run typecheck:test` *(fails: Cannot find type definition file for 'jest' and 'node')*
- `npm test` *(fails at typecheck step: Cannot find type definition file for 'jest' and 'node')*