### PR TITLE
Fix tests for baseCoin property

### DIFF
--- a/__tests__/components/symbol/SymbolList.test.tsx
+++ b/__tests__/components/symbol/SymbolList.test.tsx
@@ -10,8 +10,8 @@ import type { SymbolInfo } from '@/types/common/symbol';
 
 // モックシンボルデータ
 const mockSymbols: SymbolInfo[] = [
-  { symbol: 'BTCUSDT', baseAsset: 'BTC', quoteCoin: 'USDT', favorite: false },
-  { symbol: 'ETHUSDT', baseAsset: 'ETH', quoteCoin: 'USDT', favorite: true },
+  { symbol: 'BTCUSDT', baseCoin: 'BTC', quoteCoin: 'USDT', favorite: false },
+  { symbol: 'ETHUSDT', baseCoin: 'ETH', quoteCoin: 'USDT', favorite: true },
 ];
 
 // validateSymbolInfoのモック

--- a/__tests__/hooks/symbol/usePopularSymbols.test.ts
+++ b/__tests__/hooks/symbol/usePopularSymbols.test.ts
@@ -9,11 +9,11 @@ import type { FilterOptions, SymbolInfo } from '@/store/useSymbolStore';
 
 // モックシンボルデータ
 const mockSymbols: SymbolInfo[] = [
-  { symbol: 'BTCUSDT', baseAsset: 'BTC', quoteCoin: 'USDT', favorite: false },
-  { symbol: 'ETHUSDT', baseAsset: 'ETH', quoteCoin: 'USDT', favorite: true },
-  { symbol: 'BNBBTC', baseAsset: 'BNB', quoteCoin: 'BTC', favorite: false },
-  { symbol: 'SOLUSDT', baseAsset: 'SOL', quoteCoin: 'USDT', favorite: false },
-  { symbol: 'MATICUSDT', baseAsset: 'MATIC', quoteCoin: 'USDT', favorite: false },
+  { symbol: 'BTCUSDT', baseCoin: 'BTC', quoteCoin: 'USDT', favorite: false },
+  { symbol: 'ETHUSDT', baseCoin: 'ETH', quoteCoin: 'USDT', favorite: true },
+  { symbol: 'BNBBTC', baseCoin: 'BNB', quoteCoin: 'BTC', favorite: false },
+  { symbol: 'SOLUSDT', baseCoin: 'SOL', quoteCoin: 'USDT', favorite: false },
+  { symbol: 'MATICUSDT', baseCoin: 'MATIC', quoteCoin: 'USDT', favorite: false },
 ];
 
 // デフォルトフィルターオプション
@@ -89,8 +89,8 @@ describe('usePopularSymbols', () => {
   test('シンボルリストがPOPULAR_SYMBOLSに含まれない場合、空配列を返す', () => {
     // POPULAR_SYMBOLSに含まれないシンボルのみのリスト
     const nonPopularSymbols: SymbolInfo[] = [
-      { symbol: 'XRPBTC', baseAsset: 'XRP', quoteCoin: 'BTC', favorite: false },
-      { symbol: 'LRCETH', baseAsset: 'LRC', quoteCoin: 'ETH', favorite: false },
+      { symbol: 'XRPBTC', baseCoin: 'XRP', quoteCoin: 'BTC', favorite: false },
+      { symbol: 'LRCETH', baseCoin: 'LRC', quoteCoin: 'ETH', favorite: false },
     ];
     
     const { result } = renderHook(() => 

--- a/__tests__/validations/market.test.ts
+++ b/__tests__/validations/market.test.ts
@@ -244,8 +244,8 @@ describe('Market Validations', () => {
     it('有効な銘柄情報を検証できる', () => {
       const validSymbol = {
         symbol: 'BTCUSDT',
-        baseCoin: 'BTC', // baseAsset → baseCoin に修正
-        quoteCoin: 'USDT', // quoteCoin → quoteCoin に修正
+        baseCoin: 'BTC', // baseCoin に修正
+        quoteCoin: 'USDT', // quoteCoin に修正
         minOrderSize: 0.001, // minNotional → minOrderSize に修正
         pricePrecision: 2,
         quantityPrecision: 6,
@@ -260,8 +260,8 @@ describe('Market Validations', () => {
     it('validateSymbolInfo関数が正しく動作する', () => {
       const validSymbol = {
         symbol: 'BTCUSDT',
-        baseCoin: 'BTC', // baseAsset → baseCoin に修正
-        quoteCoin: 'USDT', // quoteCoin → quoteCoin に修正
+        baseCoin: 'BTC', // baseCoin に修正
+        quoteCoin: 'USDT', // quoteCoin に修正
         minOrderSize: 0.001, // minNotional → minOrderSize に修正
         pricePrecision: 2,
         quantityPrecision: 6,

--- a/__tests__/validations/symbol.test.ts
+++ b/__tests__/validations/symbol.test.ts
@@ -17,7 +17,7 @@ describe('Symbol Validations', () => {
     it('有効なシンボル情報を検証できる', () => {
       const validSymbol = {
         symbol: 'BTCUSDT',
-        baseAsset: 'BTC',
+        baseCoin: 'BTC',
         quoteCoin: 'USDT',
         pricePrecision: 2,
         quantityPrecision: 6,
@@ -33,7 +33,7 @@ describe('Symbol Validations', () => {
     it('無効なシンボル情報を検出できる', () => {
       const invalidSymbol = {
         symbol: '', // 空文字列は無効
-        baseAsset: 'BTC',
+        baseCoin: 'BTC',
         quoteCoin: 'USDT',
         pricePrecision: 2,
         quantityPrecision: 6,
@@ -48,7 +48,7 @@ describe('Symbol Validations', () => {
     it('validateSymbolInfo関数が正しく動作する', () => {
       const validSymbol = {
         symbol: 'BTCUSDT',
-        baseAsset: 'BTC',
+        baseCoin: 'BTC',
         quoteCoin: 'USDT',
         pricePrecision: 2,
         quantityPrecision: 6,


### PR DESCRIPTION
## Summary
- update SymbolList test to use `baseCoin`
- replace `baseAsset` with `baseCoin` in popular symbols hook test
- change validation tests to expect `baseCoin`
- clean up comments in market validation test

## Testing
- `npm test` *(fails: Cannot find type definition file for 'jest')*