### PR TITLE
Update product type imports and tests

### DIFF
--- a/__tests__/integration/data-flow/instrument-type-change-flow.test.ts
+++ b/__tests__/integration/data-flow/instrument-type-change-flow.test.ts
@@ -6,7 +6,7 @@
 import { changeInstrumentTypeTool } from '../../../src/mastra/tools/instrument-type-tools';
 import { useRootStore } from '../../../store/rootStore';
 import { logger } from '../../../utils/common';
-import { ProductType } from '../../../types/api';
+import { ProductType } from '@/types/api';
 
 // モジュールをモック化
 jest.mock('../../../src/mastra/tools/instrument-type-tools', () => ({

--- a/__tests__/services/socket/bitget-integration.test.ts
+++ b/__tests__/services/socket/bitget-integration.test.ts
@@ -7,7 +7,7 @@
 
 import { BitgetIntegration } from '../../../services/socket/bitget-integration';
 import { BitgetApiClient } from '../../../services/api/bitget/client';
-import { ProductType } from '../../../types/api';
+import { ProductType } from '@/types/api';
 import { logger } from '../../../utils/logger';
 
 // BitgetApiClientのモック

--- a/__tests__/services/socket/socket-service.test.ts
+++ b/__tests__/services/socket/socket-service.test.ts
@@ -10,7 +10,7 @@ import { SocketService } from '../../../services/socket/socket-service';
 import { IWebSocketClient, ISubscriptionManager, IBitgetIntegration } from '../../../services/socket/interfaces';
 import { OrderBookData } from '../../../types/market';
 import { OHLCData } from '../../../types/chart';
-import { ProductType } from '../../../types/api';
+import { ProductType } from '@/types/api';
 import { BitgetApiClient } from '../../../services/api/bitget/client';
 import { logger } from '../../../utils/logger';
 

--- a/__tests__/services/socket/subscription-manager.test.ts
+++ b/__tests__/services/socket/subscription-manager.test.ts
@@ -11,7 +11,7 @@ import { SubscriptionManager, CHANNEL } from '../../../services/socket/subscript
 import { IWebSocketClient } from '../../../services/socket/interfaces';
 import { OrderBookData } from '../../../types/market';
 import { OHLCData } from '../../../types/chart';
-import { ProductType } from '../../../types/api';
+import { ProductType } from '@/types/api';
 
 // WebSocketClientとloggerのモジュールをモック
 jest.mock('../../../services/socket/websocket-client', () => ({

--- a/__tests__/services/test-bitget-api.ts
+++ b/__tests__/services/test-bitget-api.ts
@@ -6,20 +6,20 @@
  */
 
 import { BitgetApiClient } from '../../services/api/bitget/client';
-import { ExchangeType } from '../../types/api';
+import { ProductType } from '@/types/api';
 import { OHLCData } from '../../types/chart';
 
 // テスト設定
 const TEST_SYMBOLS = ['BTC/USDT', 'ETH/USDT'];
 const TEST_TIMEFRAMES = ['1m', '1h', '1d'];
-const EXCHANGE_TYPES: ExchangeType[] = ['spot', 'futures'];
+const PRODUCT_TYPES: ProductType[] = ['spot', 'futures'];
 
 async function testHistoricalData() {
   console.log('=== 過去のローソク足データ取得テスト ===');
   
-  for (const exchangeType of EXCHANGE_TYPES) {
-    console.log(`\n[${exchangeType.toUpperCase()}取引のテスト]`);
-    const api = new BitgetApiClient({}, exchangeType);
+  for (const productType of PRODUCT_TYPES) {
+    console.log(`\n[${productType.toUpperCase()}取引のテスト]`);
+    const api = new BitgetApiClient({}, productType);
     
     for (const symbol of TEST_SYMBOLS) {
       for (const timeframe of TEST_TIMEFRAMES) {
@@ -56,7 +56,7 @@ function testWebSocket() {
   const timeframe = '1m';
   
   console.log(`WebSocket接続をテスト中... (${symbol} ${timeframe})`);
-  const api = new BitgetApiClient({}, 'spot');
+  const api = new BitgetApiClient({}, 'spot' as ProductType);
   
   // WebSocket接続を確立
   api.connectWebSocket();

--- a/__tests__/unit/tools/instrument-type-tools.test.ts
+++ b/__tests__/unit/tools/instrument-type-tools.test.ts
@@ -5,7 +5,7 @@
 import { changeInstrumentTypeTool } from '../../../src/mastra/tools/instrument-type-tools';
 import { logger } from '../../../utils/logger';
 import fetch from 'node-fetch'; // Import to mock
-import { ExchangeType, ProductType } from '../../../types/api';
+import { ExchangeType, ProductType } from '@/types/api';
 
 // Mock logger
 jest.mock('../../../utils/logger', () => ({

--- a/__tests__/unit/tools/symbol-tools.test.ts
+++ b/__tests__/unit/tools/symbol-tools.test.ts
@@ -5,7 +5,7 @@
 import { changeSymbolTool } from '../../../src/mastra/tools/symbol-tools';
 import { logger } from '../../../utils/logger';
 import fetch from 'node-fetch'; // Import to mock
-import { ExchangeType, ProductType } from '../../../types/api';
+import { ExchangeType, ProductType } from '@/types/api';
 
 // Mock logger
 jest.mock('../../../utils/logger', () => ({

--- a/__tests__/unit/utils/socketClient.test.ts
+++ b/__tests__/unit/utils/socketClient.test.ts
@@ -1,5 +1,5 @@
 // 型のみをトップレベルでインポート
-import { ExchangeType, ProductType } from '../../../types/api';
+import { ExchangeType, ProductType } from '@/types/api';
 import { Timeframe } from '../../../types/chart';
 import type { Socket } from 'socket.io-client'; // Socket 型をインポート (DisconnectReason を削除)
 

--- a/services/api/bitget/client.new.ts
+++ b/services/api/bitget/client.new.ts
@@ -9,7 +9,7 @@
  * 既存の実装との互換性を保ちながら、段階的なリファクタリングを可能にします。
  */
 
-import { ProductType, BitgetCredentials } from '../../../types/api';
+import { ProductType, BitgetCredentials } from '@/types/api';
 import { OHLCData } from '../../../types/chart';
 import { OrderBookData } from '../../../types/market';
 import { IRestApiClient, IWebSocketClient } from '../interfaces';

--- a/services/api/bitget/client.ts
+++ b/services/api/bitget/client.ts
@@ -9,7 +9,7 @@
  * 既存の実装との互換性を保ちながら、段階的なリファクタリングを可能にします。
  */
 
-import { ProductType, BitgetCredentials } from '../../../types/api';
+import { ProductType, BitgetCredentials } from '@/types/api';
 import { OHLCData } from '../../../types/chart';
 import { OrderBookData } from '../../../types/market';
 import { IRestApiClient, IWebSocketClient } from '../interfaces';

--- a/services/api/bitget/data-transformer.ts
+++ b/services/api/bitget/data-transformer.ts
@@ -8,7 +8,7 @@
  * このファイルは、APIレスポンスの正規化とWebSocketメッセージのパースを担当します。
  */
 
-import { ExchangeType } from '../../../types/api';
+import { ExchangeType } from '@/types/api';
 import { OHLCData, Timeframe } from '../../../types/chart';
 import { OrderBookData } from '../../../types/market';
 import { logger } from '@/utils/common';

--- a/services/api/bitget/interfaces.ts
+++ b/services/api/bitget/interfaces.ts
@@ -8,7 +8,7 @@
  * 既存の実装との互換性を保ちながら、段階的なリファクタリングを可能にします。
  */
 
-import { ProductType, BitgetCredentials } from '../../../types/api';
+import { ProductType, BitgetCredentials } from '@/types/api';
 import { OHLCData } from '../../../types/chart';
 import { OrderBookData } from '../../../types/market';
 import { IRestApiClient, IWebSocketClient } from '../interfaces';

--- a/services/api/bitget/rest-client.ts
+++ b/services/api/bitget/rest-client.ts
@@ -11,7 +11,7 @@
  */
 
 import axios, { AxiosError } from 'axios';
-import { ExchangeType, ExchangeProductType } from '../../../types/api';
+import { ExchangeType, ExchangeProductType } from '@/types/api';
 import { OHLCData, Timeframe, OrderBookData } from '../../../types/chart';
 import { IRestApiClient } from '../interfaces';
 import { logger } from '../../../utils/logger';

--- a/services/api/bitget/ws-client.new.ts
+++ b/services/api/bitget/ws-client.new.ts
@@ -8,7 +8,7 @@
  * 接続管理、メッセージ送受信、Ping/Pong処理、再接続ロジックを実装します。
  */
 
-import { ProductType, BitgetCredentials } from '../../../types/api';
+import { ProductType, BitgetCredentials } from '@/types/api';
 import { OHLCData, Timeframe } from '../../../types/chart';
 import { OrderBookData } from '../../../types/market';
 import { logger } from '@/utils/common';

--- a/services/api/bitget/ws-client.ts
+++ b/services/api/bitget/ws-client.ts
@@ -8,7 +8,7 @@
  * 接続管理、メッセージ送受信、Ping/Pong処理、再接続ロジックを実装します。
  */
 
-import { BitgetCredentials } from '../../../types/api';
+import { BitgetCredentials } from '@/types/api';
 import { OHLCData, Timeframe } from '../../../types/chart';
 import { OrderBookData } from '@/types/common/orderbook';
 import { ExchangeType, ProductType } from '@/types/constants/enums';

--- a/services/api/chart-data-service.new.ts
+++ b/services/api/chart-data-service.new.ts
@@ -10,7 +10,7 @@
  */
 
 import { EventEmitter } from 'events';
-import { ExchangeType } from '../../types/api';
+import { ExchangeType } from '@/types/api';
 import { OHLCData, OrderBookData, Timeframe } from '../../types/chart';
 import { IChartDataService } from './interfaces';
 import { dataSourceFactory } from './data-source-factory';

--- a/services/api/chart-data-service.ts
+++ b/services/api/chart-data-service.ts
@@ -10,7 +10,7 @@
  */
 
 import { EventEmitter } from 'events';
-import { ExchangeType } from '../../types/api';
+import { ExchangeType } from '@/types/api';
 import { OHLCData, OrderBookData, Timeframe } from '../../types/chart';
 import { IChartDataService } from './interfaces';
 import { dataSourceFactory } from './data-source-factory';

--- a/services/api/common/request.ts
+++ b/services/api/common/request.ts
@@ -9,7 +9,7 @@ import {
   ApiRequestConfig,
   AdaptiveApiRequestConfig,
   CancellableRequest
-} from '../../../types/api';
+} from '@/types/api';
 import { IS_DEV, IS_BROWSER, getApiConfig } from './environment';
 
 /**

--- a/services/data/chart-data-service.ts
+++ b/services/data/chart-data-service.ts
@@ -10,7 +10,7 @@ import { EventEmitter } from 'events';
 import { BitgetApiClient } from '../api/bitget/client';
 import { IChartDataService } from './interfaces';
 import { OHLCData, Timeframe } from '../../types/chart';
-import { ExchangeType } from '../../types/api';
+import { ExchangeType } from '@/types/api';
 import { logger } from '../../utils/logger';
 import { normalizeSymbol } from '../../utils/formatters';
 import { getSocketService } from '../socket/index';

--- a/services/data/dataFetchService.ts
+++ b/services/data/dataFetchService.ts
@@ -17,7 +17,7 @@ import { EventEmitter } from 'events';
 import { BitgetApiClient } from '../api/bitget/client';
 import { IDataFetchService } from './dataFetchTypes';
 import { OHLCData, Timeframe } from '../../types/chart';
-import { ExchangeType } from '../../types/api';
+import { ExchangeType } from '@/types/api';
 import { logger } from '../../utils/logger';
 import { normalizeSymbol } from '../../utils/formatters';
 import { getSocketService } from '../socket/service';

--- a/services/data/dataFetchTypes.ts
+++ b/services/data/dataFetchTypes.ts
@@ -5,7 +5,7 @@
  * 作成: データフェッチサービスのインターフェースと型定義
  */
 
-import { ExchangeType } from '../../types/api';
+import { ExchangeType } from '@/types/api';
 import { OHLCData, Timeframe } from '../../types/chart';
 
 export interface IDataFetchService {

--- a/services/data/interfaces.ts
+++ b/services/data/interfaces.ts
@@ -6,7 +6,7 @@
  * 各サービスのインターフェースを明確に定義
  */
 
-import { ExchangeType } from '../../types/api';
+import { ExchangeType } from '@/types/api';
 import { OHLCData, Timeframe, OrderBookData } from '../../types/chart';
 
 /**

--- a/services/data/order-book-service.ts
+++ b/services/data/order-book-service.ts
@@ -10,7 +10,7 @@ import { EventEmitter } from 'events';
 import { BitgetApiClient } from '../api/bitget/client';
 import { IOrderBookService } from '../api/interfaces';
 import { OrderBookData } from '../../types/chart';
-import { ExchangeType } from '../../types/api';
+import { ExchangeType } from '@/types/api';
 import { logger } from '../../utils/logger';
 import { normalizeSymbol } from '../../utils/formatters';
 import { getSocketService } from '../socket/service';

--- a/services/errors/handler.ts
+++ b/services/errors/handler.ts
@@ -4,7 +4,7 @@
 
 import { toast } from 'sonner';
 import { AxiosError } from 'axios';
-import { ApiErrorHandlerOptions, WebSocketErrorHandlerOptions } from '../../types/api';
+import { ApiErrorHandlerOptions, WebSocketErrorHandlerOptions } from '@/types/api';
 import { IS_DEV, IS_BROWSER } from '../api/common/environment';
 
 // エラーの種類を区別するための型

--- a/services/socket/bitget-integration.ts
+++ b/services/socket/bitget-integration.ts
@@ -6,7 +6,7 @@
  * 変更: index.tsからBitgetAPI統合機能を分離
  */
 
-import { ProductType } from '../../types/api';
+import { ProductType } from '@/types/api';
 import { BitgetApiClient } from '../api/bitget/client';
 import { logger } from '../../utils/logger';
 import { IBitgetIntegration } from './interfaces';

--- a/services/socket/interfaces.ts
+++ b/services/socket/interfaces.ts
@@ -9,7 +9,7 @@
 import { Socket } from 'socket.io-client';
 import { OrderBookData } from '../../types/market';
 import { OHLCData, Timeframe } from '../../types/chart';
-import { ProductType } from '../../types/api';
+import { ProductType } from '@/types/api';
 
 /**
  * WebSocket接続管理インターフェース

--- a/services/socket/mock-service.ts
+++ b/services/socket/mock-service.ts
@@ -9,7 +9,7 @@
 import { EventEmitter } from 'events';
 import { OrderBookData, OrderBookEntry } from '@/types/common/orderbook';
 import { OHLCData, Timeframe } from '../../types/chart';
-import { ProductType } from '../../types/api';
+import { ProductType } from '@/types/api';
 import { logger } from '../../utils/logger';
 import { ISocketService } from './interfaces';
 

--- a/services/socket/service.ts
+++ b/services/socket/service.ts
@@ -7,7 +7,7 @@ import { EventEmitter } from 'events';
 import { Socket } from 'socket.io-client';
 import { OrderBookData } from '../../types/market';
 import { OHLCData, Timeframe } from '../../types/chart';
-import { ExchangeType } from '../../types/api';
+import { ExchangeType } from '@/types/api';
 import { logger } from '../../utils/logger';
 import { ISocketService } from './interfaces';
 

--- a/services/socket/socket-service.ts
+++ b/services/socket/socket-service.ts
@@ -9,7 +9,7 @@
 import { Socket } from 'socket.io-client';
 import { OrderBookData } from '../../types/market';
 import { OHLCData, Timeframe } from '../../types/chart';
-import { ProductType } from '../../types/api';
+import { ProductType } from '@/types/api';
 import { BitgetApiClient } from '../api/bitget/client';
 import { logger } from '../../utils/logger';
 import { 

--- a/services/socket/subscription-manager.ts
+++ b/services/socket/subscription-manager.ts
@@ -9,7 +9,7 @@
 import { Socket } from 'socket.io-client';
 import { OrderBookData } from '../../types/market';
 import { OHLCData, Timeframe } from '../../types/chart';
-import { ProductType } from '../../types/api';
+import { ProductType } from '@/types/api';
 import { normalizeSymbol } from '../../lib/utils';
 import { logger } from '../../utils/logger';
 import { ISubscriptionManager, IWebSocketClient } from './interfaces';


### PR DESCRIPTION
## Summary
- use `ProductType` alias imports in tests and services
- convert Bitget API demo script to use ProductType constants

## Testing
- `npm test` *(fails: Cannot find type definition file for 'jest')*