### PR TITLE
Fix drawing tool null check and add test

### DIFF
--- a/__tests__/components/ChartFooter.test.tsx
+++ b/__tests__/components/ChartFooter.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ChartFooter } from '@/components/chart/container/ChartFooter';
+import type { DrawingToolType } from '@/types/store/chart';
+
+// simple helpers
+const noop = () => {};
+
+describe('ChartFooter null activeDrawingTools', () => {
+  it('renders without active class when activeDrawingTools is null', () => {
+    render(
+      <ChartFooter
+        activeIndicators={[]}
+        activeDrawingTools={null as unknown as DrawingToolType[]}
+        handleToggleIndicator={noop}
+        handleToggleDrawingTool={noop}
+        clearAllIndicators={noop}
+        clearAllDrawingTools={noop}
+      />
+    );
+
+    const fibButton = screen.getByText('Fibonacci');
+    expect(fibButton.className).toBe('');
+  });
+});

--- a/components/chart/container/ChartFooter.tsx
+++ b/components/chart/container/ChartFooter.tsx
@@ -67,7 +67,7 @@ export const ChartFooter: React.FC<ChartFooterProps> = ({
       <div className="drawing-tool-controls">
         <h4>Drawing Tools</h4>
         <button 
-          className={activeDrawingTools.includes('fibonacci') ? 'active' : ''} 
+          className={activeDrawingTools?.includes('fibonacci') ? 'active' : ''}
           onClick={() => handleToggleDrawingTool('fibonacci')}
         >
           Fibonacci

--- a/components/chart/drawings/useDrawingTools.ts
+++ b/components/chart/drawings/useDrawingTools.ts
@@ -53,7 +53,7 @@ export function useDrawingTools(): UseDrawingToolsReturn {
     if (!chartInstance || !mainSeries || !data || data.length === 0) return;
     
     // フィボナッチリトレースメントの表示切替
-    if (activeDrawingTools.includes('fibonacci')) {
+    if (activeDrawingTools?.includes('fibonacci')) {
       // データから高値と安値を取得
       const sortedData = [...data].sort((a, b) => a.time - b.time);
       const last30Data = sortedData.slice(-30); // 直近30本のデータを使用


### PR DESCRIPTION
## Summary
- fix fibonacci tool conditional for null safety
- test ChartFooter when activeDrawingTools is null

## Testing
- `npm test` *(fails: cannot find type definition file for 'jest')*