### PR TITLE
Fix supabase client mocks in tests

### DIFF
--- a/__tests__/api/reset-password.test.tsx
+++ b/__tests__/api/reset-password.test.tsx
@@ -7,7 +7,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 import { useSearchParams } from 'next/navigation';
 import ResetPasswordPage from '@/app/reset-password/page';
-import { supabase } from '@/lib/supabase/supabase';
+import { createClient } from '@/lib/supabase/client';
 
 // モック
 jest.mock('next/navigation', () => ({
@@ -15,13 +15,15 @@ jest.mock('next/navigation', () => ({
   useSearchParams: jest.fn(),
 }));
 
-jest.mock('@/lib/supabase/supabase', () => ({
-  supabase: {
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: jest.fn(() => ({
     auth: {
       updateUser: jest.fn(),
     },
-  },
+  }))
 }));
+
+const supabase = createClient();
 
 describe('ResetPasswordPage', () => {
   const mockUpdateUser = jest.fn();

--- a/__tests__/hooks/useAuth.test.tsx
+++ b/__tests__/hooks/useAuth.test.tsx
@@ -6,12 +6,12 @@
 
 import { renderHook, act } from '@testing-library/react';
 import { useAuth } from '@/hooks/auth/useAuth';
-import { supabase } from '@/lib/supabase/supabase';
+import { createClient } from '@/lib/supabase/client';
 import { getProfile, updateProfile } from '@/lib/supabase/features/auth';
 
 // モック
-jest.mock('@/lib/supabase/supabase', () => ({
-  supabase: {
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: jest.fn(() => ({
     auth: {
       getSession: jest.fn(),
       onAuthStateChange: jest.fn(() => ({
@@ -26,7 +26,7 @@ jest.mock('@/lib/supabase/supabase', () => ({
       signOut: jest.fn(),
       resetPasswordForEmail: jest.fn(),
     }
-  }
+  }))
 }));
 
 jest.mock('next/navigation', () => ({
@@ -39,6 +39,8 @@ jest.mock('@/lib/supabase/features/auth', () => ({
   getProfile: jest.fn(),
   updateProfile: jest.fn()
 }));
+
+const supabase = createClient();
 
 describe('useAuth Hook', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- update api and hooks tests to import `createClient`
- mock `createClient` and use a client instance for auth calls

## Testing
- `npm test -- __tests__/api/reset-password.test.tsx __tests__/hooks/useAuth.test.tsx` *(fails: Cannot find type definition file for 'jest')*