### PR TITLE
Fix orderbook tests to use exchange name

### DIFF
--- a/__tests__/api/rest-client.test.ts
+++ b/__tests__/api/rest-client.test.ts
@@ -41,7 +41,7 @@ describe('BitgetRestClient', () => {
     mockedAxios.get.mockResolvedValueOnce(mockResponse);
     
     // オーダーブックデータを取得
-    const result = await client.getOrderBook('BTC/USDT', 'spot' as ProductType);
+    const result = await client.getOrderBook('BTC/USDT', 'bitget' as ProductType);
     
     // axiosが正しいエンドポイントとパラメータで呼び出されたことを確認
     expect(mockedAxios.get).toHaveBeenCalledWith(
@@ -67,7 +67,7 @@ describe('BitgetRestClient', () => {
     mockedAxios.get.mockRejectedValueOnce(new Error('Network error'));
     
     // オーダーブックデータを取得
-    const result = await client.getOrderBook('BTC/USDT', 'spot' as ProductType);
+    const result = await client.getOrderBook('BTC/USDT', 'bitget' as ProductType);
     
     // デモデータが返されたことを確認
     expect(result).toEqual({

--- a/__tests__/data/order-book-service.test.ts
+++ b/__tests__/data/order-book-service.test.ts
@@ -57,10 +57,10 @@ describe('OrderBookService - ユニットテスト', () => {
     (BitgetApiClient as jest.Mock).mockImplementation(() => mockInstance);
     
     // オーダーブックデータを取得
-    const result = await orderBookService.getOrderBook('BTC/USDT', 'spot');
+    const result = await orderBookService.getOrderBook('BTC/USDT', 'bitget');
     
     // 検証 - 新しいAPIのメソッド名に合わせて修正
-    expect(mockFetchOrderBook).toHaveBeenCalledWith('BTC/USDT', expect.any(Number), 'spot');
+    expect(mockFetchOrderBook).toHaveBeenCalledWith('BTC/USDT', expect.any(Number), 'bitget');
     expect(result).toEqual(mockOrderBookData);
   });
   
@@ -130,13 +130,13 @@ describe('OrderBookService - ユニットテスト', () => {
     });
     
     // モック関数を呼び出す
-    mockSubscribeOrderBookRealtime('BTC/USDT', callbackMock, 'spot');
+    mockSubscribeOrderBookRealtime('BTC/USDT', callbackMock, 'bitget');
     
     // 検証
     expect(mockSocketService.subscribeOrderBook).toHaveBeenCalledWith(
       'BTC/USDT',
       callbackMock,
-      'spot'
+      'bitget'
     );
   });
   
@@ -150,9 +150,9 @@ describe('OrderBookService - ユニットテスト', () => {
     // @ts-ignore - プライベートプロパティにアクセスするため
     orderBookService.subscriptions = new Map();
     // @ts-ignore - プライベートプロパティにアクセスするため
-    orderBookService.subscriptions.set('orderbook-BTC/USDT-spot', unsubscribeMock1);
+    orderBookService.subscriptions.set('orderbook-BTC/USDT-bitget', unsubscribeMock1);
     // @ts-ignore - プライベートプロパティにアクセスするため
-    orderBookService.subscriptions.set('orderbook-ETH/USDT-spot', unsubscribeMock2);
+    orderBookService.subscriptions.set('orderbook-ETH/USDT-bitget', unsubscribeMock2);
     
     // すべての購読を解除
     orderBookService.unsubscribeAll();
@@ -168,7 +168,7 @@ describe('OrderBookService - ユニットテスト', () => {
 describe('OrderBookService - 統合テスト', () => {
   // このテストはスキップされます（CIでは実行されません）
   it.skip('orderBookServiceがオーダーブックデータを取得できる', async () => {
-    const result = await orderBookService.getOrderBook('BTC/USDT', 'spot');
+    const result = await orderBookService.getOrderBook('BTC/USDT', 'bitget');
     
     // 検証
     expect(result).toBeDefined();

--- a/__tests__/services/api/bitget/rest-client.test.ts
+++ b/__tests__/services/api/bitget/rest-client.test.ts
@@ -377,10 +377,10 @@ describe('BitgetRestClient', () => {
       const spy = jest.spyOn(client, 'fetchOrderBook');
       
       // getOrderBookの実行
-      await client.getOrderBook('BTC/USDT', 'spot');
+      await client.getOrderBook('BTC/USDT', 'bitget');
       
       // fetchOrderBookが正しく呼び出されたか確認
-      expect(spy).toHaveBeenCalledWith('BTC/USDT', 100, 'spot');
+      expect(spy).toHaveBeenCalledWith('BTC/USDT', 100, 'bitget');
     });
   });
 


### PR DESCRIPTION
## Summary
- update getOrderBook calls in tests to use `bitget` exchange

## Testing
- `npm run typecheck:test` *(fails: Cannot find type definition file for 'jest')*
- `npm test` *(fails: Cannot find type definition file for 'jest')*