### PR TITLE
Fix drawing tool state naming

### DIFF
--- a/__tests__/components/ChartContainer.test.tsx
+++ b/__tests__/components/ChartContainer.test.tsx
@@ -36,7 +36,7 @@ jest.mock('@/store/chart', () => ({
     clearAllIndicators: jest.fn()
   })),
   useDrawingToolStore: jest.fn(() => ({
-    activeDrawingTools: [],
+    activeDrawingTool: null,
     toggleDrawingTool: jest.fn(),
     clearAllDrawingTools: jest.fn()
   })),

--- a/__tests__/components/ChartFooter.test.tsx
+++ b/__tests__/components/ChartFooter.test.tsx
@@ -6,12 +6,12 @@ import type { DrawingToolType } from '@/types/store/chart';
 // simple helpers
 const noop = () => {};
 
-describe('ChartFooter null activeDrawingTools', () => {
-  it('renders without active class when activeDrawingTools is null', () => {
+describe('ChartFooter null activeDrawingTool', () => {
+  it('renders without active class when activeDrawingTool is null', () => {
     render(
       <ChartFooter
         activeIndicators={[]}
-        activeDrawingTools={null as unknown as DrawingToolType[]}
+        activeDrawingTool={null as unknown as DrawingToolType}
         handleToggleIndicator={noop}
         handleToggleDrawingTool={noop}
         clearAllIndicators={noop}

--- a/components/chart/Canvas/index.tsx
+++ b/components/chart/Canvas/index.tsx
@@ -69,7 +69,7 @@ export default function ChartCanvas() {
   // 型の互換性を確保するために拡張型定義を使用
   const chartType = useRootStore(selectChartType as any) as ExtendedChartType;
   const activeIndicators = useRootStore(selectActiveIndicators);
-  const activeDrawingTools = useRootStore(selectActiveDrawingTool);
+  const activeDrawingTool = useRootStore(selectActiveDrawingTool);
   
   // チャートタイプが変更されたときにシリーズを切り替え
   useEffect(() => {
@@ -203,9 +203,9 @@ export default function ChartCanvas() {
     logger.debug('描画ツールを更新しました', {
       component: 'ChartCanvas',
       action: 'updateDrawings',
-      activeDrawingTools
+      activeDrawingTool
     });
-  }, [data, activeDrawingTools, chartInstanceRef, seriesRefs, updateDrawings]);
+  }, [data, activeDrawingTool, chartInstanceRef, seriesRefs, updateDrawings]);
 
   return (
     <div

--- a/components/chart/container/ChartBody.tsx
+++ b/components/chart/container/ChartBody.tsx
@@ -23,7 +23,7 @@ interface ChartBodyProps {
   exchangeType: ExchangeType;
   chartData: OHLCData[] | null;
   activeIndicators: ActiveIndicator[];
-  activeDrawingTools: string[];
+  activeDrawingTool: string | null;
 }
 
 /**
@@ -39,7 +39,7 @@ export const ChartBody: React.FC<ChartBodyProps> = ({
   exchangeType,
   chartData,
   activeIndicators,
-  activeDrawingTools
+  activeDrawingTool
 }) => {
   return (
     <div className="chart-body">
@@ -57,11 +57,8 @@ export const ChartBody: React.FC<ChartBodyProps> = ({
           }
         </p>
         <p>
-          Active Drawing Tools: 
-          {activeDrawingTools.length === 0 
-            ? ' None' 
-            : ` ${activeDrawingTools.join(', ')}`
-          }
+          Active Drawing Tool:
+          {activeDrawingTool ? ` ${activeDrawingTool}` : ' None'}
         </p>
       </div>
     </div>

--- a/components/chart/container/ChartFooter.tsx
+++ b/components/chart/container/ChartFooter.tsx
@@ -15,7 +15,7 @@ import type { ActiveIndicator, IndicatorType, DrawingToolType } from '@/types/st
 interface ChartFooterProps {
   // 表示データ
   activeIndicators: ActiveIndicator[];
-  activeDrawingTools: DrawingToolType[];
+  activeDrawingTool: DrawingToolType | null;
   
   // 操作関数
   handleToggleIndicator: (indicator: IndicatorType) => void;
@@ -31,7 +31,7 @@ interface ChartFooterProps {
  */
 export const ChartFooter: React.FC<ChartFooterProps> = ({
   activeIndicators,
-  activeDrawingTools,
+  activeDrawingTool,
   handleToggleIndicator,
   handleToggleDrawingTool,
   clearAllIndicators,
@@ -66,14 +66,14 @@ export const ChartFooter: React.FC<ChartFooterProps> = ({
       
       <div className="drawing-tool-controls">
         <h4>Drawing Tools</h4>
-        <button 
-          className={activeDrawingTools?.includes('fibonacci') ? 'active' : ''}
+        <button
+          className={activeDrawingTool === 'fibonacci' ? 'active' : ''}
           onClick={() => handleToggleDrawingTool('fibonacci')}
         >
           Fibonacci
         </button>
-        <button 
-          className={activeDrawingTools.includes('rectangle') ? 'active' : ''} 
+        <button
+          className={activeDrawingTool === 'rectangle' ? 'active' : ''}
           onClick={() => handleToggleDrawingTool('rectangle')}
         >
           Rectangle

--- a/components/chart/container/index.tsx
+++ b/components/chart/container/index.tsx
@@ -65,7 +65,7 @@ export default function ChartContainer() {
     clearAllIndicators,
     
     // 描画ツール関連
-    activeDrawingTools,
+    activeDrawingTool,
     toggleDrawingTool,
     clearAllDrawingTools,
     
@@ -158,12 +158,12 @@ export default function ChartContainer() {
         exchangeType={exchangeType as ExchangeType}
         chartData={chartData}
         activeIndicators={convertToActiveIndicators(activeIndicators)}
-        activeDrawingTools={activeDrawingTools}
+        activeDrawingTool={activeDrawingTool}
       />
-      
+
       <ChartFooter
         activeIndicators={convertToActiveIndicators(activeIndicators)}
-        activeDrawingTools={activeDrawingTools}
+        activeDrawingTool={activeDrawingTool}
         handleToggleIndicator={handleToggleIndicator}
         handleToggleDrawingTool={handleToggleDrawingTool}
         clearAllIndicators={clearAllIndicators}

--- a/components/chart/drawings/useDrawingTools.ts
+++ b/components/chart/drawings/useDrawingTools.ts
@@ -42,7 +42,7 @@ export function useDrawingTools(): UseDrawingToolsReturn {
   const [fibonacciLines, setFibonacciLines] = useState<FibonacciLineHandles>({});
   
   // 描画ツールストアから状態を取得
-  const activeDrawingTools = useRootStore(selectActiveDrawingTool);
+  const activeDrawingTool = useRootStore(selectActiveDrawingTool);
   
   // 描画ツールの更新
   const updateDrawings = useCallback((
@@ -53,7 +53,7 @@ export function useDrawingTools(): UseDrawingToolsReturn {
     if (!chartInstance || !mainSeries || !data || data.length === 0) return;
     
     // フィボナッチリトレースメントの表示切替
-    if (activeDrawingTools?.includes('fibonacci')) {
+    if (activeDrawingTool === 'fibonacci') {
       // データから高値と安値を取得
       const sortedData = [...data].sort((a, b) => a.time - b.time);
       const last30Data = sortedData.slice(-30); // 直近30本のデータを使用
@@ -101,7 +101,7 @@ export function useDrawingTools(): UseDrawingToolsReturn {
         });
       }
     }
-  }, [activeDrawingTools, fibonacciLines]);
+  }, [activeDrawingTool, fibonacciLines]);
   
   // すべての描画ツールをクリア
   const clearAllDrawings = useCallback((mainSeries: ISeriesApi<any>) => {
@@ -123,10 +123,10 @@ export function useDrawingTools(): UseDrawingToolsReturn {
     // 外部からupdateDrawingsを呼び出す必要がある
     logger.debug('描画ツールの状態が変更されました', {
       component: 'useDrawingTools',
-      action: 'activeDrawingToolsChanged',
-      activeTools: activeDrawingTools
+      action: 'activeDrawingToolChanged',
+      activeTool: activeDrawingTool
     });
-  }, [activeDrawingTools]);
+  }, [activeDrawingTool]);
   
   return {
     drawingHandles: {

--- a/components/chart/toolbar/__tests__/index.test.tsx
+++ b/components/chart/toolbar/__tests__/index.test.tsx
@@ -43,7 +43,7 @@ jest.mock('@/hooks/chart', () => ({
       isIndicatorActive: jest.fn(() => false)
     },
     drawingToolStore: {
-      activeDrawingTools: [],
+      activeDrawingTool: null,
       toggleDrawingTool: jest.fn(),
       clearAllDrawingTools: jest.fn()
     },

--- a/components/chart/toolbar/index.tsx
+++ b/components/chart/toolbar/index.tsx
@@ -136,8 +136,8 @@ const ChartToolbar = memo(function ChartToolbar({
           <IndicatorPopover
             isIndicatorActive={indicatorStore.isIndicatorActive}
             toggleIndicator={indicatorStore.toggleIndicator}
-            activeDrawingTools={
-              drawingToolStore.activeDrawingTools as DrawingToolState['activeDrawingTools']
+            activeDrawingTool={
+              drawingToolStore.activeDrawingTool as DrawingToolState['activeDrawingTool']
             }
             toggleDrawingTool={drawingToolStore.toggleDrawingTool}
             clearAllDrawingTools={drawingToolStore.clearAllDrawingTools}

--- a/components/chart/toolbar/ui/IndicatorPopover.tsx
+++ b/components/chart/toolbar/ui/IndicatorPopover.tsx
@@ -31,9 +31,9 @@ interface IndicatorPopoverProps {
   // インジケーター関連
   isIndicatorActive: (indicator: IndicatorType) => boolean;
   toggleIndicator: (indicator: IndicatorType) => void;
-  
+
   // 描画ツール関連
-  activeDrawingTools: DrawingToolType[];
+  activeDrawingTool: DrawingToolType | null;
   toggleDrawingTool: (tool: DrawingToolType) => void;
   clearAllDrawingTools: () => void;
 }
@@ -44,7 +44,7 @@ interface IndicatorPopoverProps {
 const IndicatorPopover = memo(function IndicatorPopover({
   isIndicatorActive,
   toggleIndicator,
-  activeDrawingTools,
+  activeDrawingTool,
   toggleDrawingTool,
   clearAllDrawingTools
 }: IndicatorPopoverProps) {
@@ -83,7 +83,7 @@ const IndicatorPopover = memo(function IndicatorPopover({
             <div key={tool.id} className="flex items-center space-x-2">
               <Checkbox
                 id={`tool-${tool.id}`}
-                checked={activeDrawingTools.includes(tool.id as DrawingToolType)}
+                checked={activeDrawingTool === (tool.id as DrawingToolType)}
                 onCheckedChange={() => toggleDrawingTool(tool.id as DrawingToolType)}
               />
               <Label

--- a/docs/store-structure.md
+++ b/docs/store-structure.md
@@ -78,8 +78,8 @@ toggleIndicator('rsi');
 import { useDrawingToolStore } from '@/store';
 
 // 使用例
-const { 
-  activeDrawingTools,   // アクティブな描画ツール
+const {
+  activeDrawingTool,   // アクティブな描画ツール
   toggleDrawingTool,    // 描画ツール切替関数
   clearAllDrawingTools  // すべての描画ツールをクリア
 } = useDrawingToolStore();

--- a/hooks/chart/canvas/useChartStores.ts
+++ b/hooks/chart/canvas/useChartStores.ts
@@ -54,7 +54,7 @@ export const useChartStores = () => {
   
   // モックデータとダミー関数（実際のアプリケーションでは実装が必要）
   const activeIndicators: IndicatorType[] = [];
-  const activeDrawingTools: DrawingToolType[] = [];
+  const activeDrawingTool: DrawingToolType | null = null;
   const toggleIndicator = (indicator: IndicatorType) => {};
   const toggleDrawingTool = (tool: DrawingToolType) => {};
   const clearAllIndicators = () => {};
@@ -91,7 +91,7 @@ export const useChartStores = () => {
     clearAllIndicators,
     
     // 描画ツール関連
-    activeDrawingTools,
+    activeDrawingTool,
     toggleDrawingTool,
     clearAllDrawingTools,
     

--- a/hooks/chart/toolbar/useToolbarStores.ts
+++ b/hooks/chart/toolbar/useToolbarStores.ts
@@ -123,7 +123,7 @@ export function useToolbarStores() {
   };
 
   // DrawingToolStoreから状態とアクションを取得（RootStoreを使用）
-  const activeDrawingTools = useRootStore(selectActiveDrawingTool);
+  const activeDrawingTool = useRootStore(selectActiveDrawingTool);
   const toggleDrawingTool = useRootStore(state => state.toggleDrawingTool);
   const clearAllDrawingTools = useRootStore(state => state.clearAllDrawingTools);
 
@@ -175,7 +175,7 @@ export function useToolbarStores() {
     
     // 描画ツール関連
     drawingToolStore: {
-      activeDrawingTools,
+      activeDrawingTool,
       toggleDrawingTool,
       clearAllDrawingTools
     },

--- a/hooks/chart/useChartStores.ts
+++ b/hooks/chart/useChartStores.ts
@@ -52,7 +52,7 @@ export const useChartStores = () => {
   
   // モックデータとダミー関数（実際のアプリケーションでは実装が必要）
   const activeIndicators: IndicatorType[] = [];
-  const activeDrawingTools: DrawingToolType[] = [];
+  const activeDrawingTool: DrawingToolType | null = null;
   const toggleIndicator = (indicator: IndicatorType) => {};
   const toggleDrawingTool = (tool: DrawingToolType) => {};
   const clearAllIndicators = () => {};
@@ -89,7 +89,7 @@ export const useChartStores = () => {
     clearAllIndicators,
     
     // 描画ツール関連
-    activeDrawingTools,
+    activeDrawingTool,
     toggleDrawingTool,
     clearAllDrawingTools,
     

--- a/hooks/chart/useToolbarStores.ts
+++ b/hooks/chart/useToolbarStores.ts
@@ -92,7 +92,7 @@ export function useToolbarStores() {
   };
 
   // DrawingToolStoreから状態とアクションを取得（RootStoreを使用）
-  const activeDrawingTools = useRootStore(selectActiveDrawingTool);
+  const activeDrawingTool = useRootStore(selectActiveDrawingTool);
   const toggleDrawingTool = useRootStore(state => state.toggleDrawingTool);
   const clearAllDrawingTools = useRootStore(state => state.clearAllDrawingTools);
 
@@ -144,7 +144,7 @@ export function useToolbarStores() {
     
     // 描画ツール関連
     drawingToolStore: {
-      activeDrawingTools,
+      activeDrawingTool,
       toggleDrawingTool,
       clearAllDrawingTools
     },

--- a/types/store/chart.ts
+++ b/types/store/chart.ts
@@ -101,7 +101,7 @@ export interface IndicatorState {
  */
 export interface DrawingToolState {
   // 状態
-  activeDrawingTools: DrawingToolType[];
+  activeDrawingTool: DrawingToolType | null;
   
   // アクション
   toggleDrawingTool: (tool: DrawingToolType) => void;


### PR DESCRIPTION
## Summary
- update UI and hooks to use `activeDrawingTool`
- align docs and tests with the new property name

## Testing
- `npm test` *(fails: Cannot find type definition file for 'jest')*