### PR TITLE
Rename product type props

### DIFF
--- a/components/symbol/Selector/SymbolSelector.tsx
+++ b/components/symbol/Selector/SymbolSelector.tsx
@@ -149,7 +149,7 @@ export default function AdvancedSymbolSelector({
   const {
     symbols: { filteredSymbols, isLoading, error },
     actions: { toggleFavorite, retryFetch },
-    exchangeType: { current: exchangeType, handleChange: handleExchangeTypeChange }
+    productType: { current: productType, handleChange: handleProductTypeChange }
   } = useSymbolSelectorLogic({
     defaultExchangeType,
     onExchangeTypeChange
@@ -224,9 +224,9 @@ export default function AdvancedSymbolSelector({
   }, [selectedSymbol, toggleFavorite]);
 
   return (
-    <AdvancedSelectorView
-      exchangeType={exchangeType}
-      onExchangeTypeChange={handleExchangeTypeChange}
+      <AdvancedSelectorView
+        productType={productType}
+        onProductTypeChange={handleProductTypeChange}
       filterOptions={filterOptions}
       commonQuoteAssets={commonQuoteAssets}
       onSearch={handleSearch}

--- a/components/symbol/Selector/ui/AdvancedSelectorView.tsx
+++ b/components/symbol/Selector/ui/AdvancedSelectorView.tsx
@@ -12,11 +12,11 @@ import { PopularList } from './PopularList';
 import { SymbolList } from './SymbolList';
 import type { FilterOptions } from '@/services/symbol';
 import type { SymbolInfo } from '@/types/common/symbol';
-import type { ExchangeType } from '@/types/constants/enums';
+import type { ProductType } from '@/types/constants/enums';
 
 interface AdvancedSelectorViewProps {
-  exchangeType: ExchangeType;
-  onExchangeTypeChange: (type: ExchangeType) => void;
+  productType: ProductType;
+  onProductTypeChange: (type: ProductType) => void;
 
   filterOptions: FilterOptions;
   commonQuoteAssets: string[];
@@ -40,8 +40,8 @@ interface AdvancedSelectorViewProps {
 }
 
 export const AdvancedSelectorView = ({
-  exchangeType,
-  onExchangeTypeChange,
+  productType,
+  onProductTypeChange,
   filterOptions,
   commonQuoteAssets,
   onSearch,
@@ -64,8 +64,8 @@ export const AdvancedSelectorView = ({
     <div className="w-full space-y-4">
       {/* 取引タイプの選択 */}
       <ExchangeTabs
-        currentExchangeType={exchangeType}
-        onExchangeTypeChange={onExchangeTypeChange}
+        currentProductType={productType}
+        onProductTypeChange={onProductTypeChange}
       />
 
       {/* 検索フィールド */}

--- a/components/symbol/Selector/ui/ExchangeTabs.tsx
+++ b/components/symbol/Selector/ui/ExchangeTabs.tsx
@@ -10,29 +10,29 @@
 "use client";
 
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import type { ExchangeType } from '@/types/constants/enums';
+import type { ProductType } from '@/types/constants/enums';
 
 interface ExchangeTabsProps {
-  currentExchangeType: ExchangeType;
-  onExchangeTypeChange: (value: ExchangeType) => void;
+  currentProductType: ProductType;
+  onProductTypeChange: (value: ProductType) => void;
 }
 
 /**
  * 取引タイプ選択タブ（現物/先物）
  */
 export const ExchangeTabs = ({
-  currentExchangeType,
-  onExchangeTypeChange
+  currentProductType,
+  onProductTypeChange
 }: ExchangeTabsProps) => {
   const handleValueChange = (value: string) => {
     // 型安全に処理
     if (value === 'spot' || value === 'futures') {
-      onExchangeTypeChange(value);
+      onProductTypeChange(value);
     }
   };
 
   return (
-    <Tabs defaultValue={currentExchangeType} onValueChange={handleValueChange}>
+    <Tabs defaultValue={currentProductType} onValueChange={handleValueChange}>
       <TabsList className="grid grid-cols-2">
         <TabsTrigger value="spot">現物</TabsTrigger>
         <TabsTrigger value="futures">先物</TabsTrigger>

--- a/hooks/symbol/selector/useSelectorStores.ts
+++ b/hooks/symbol/selector/useSelectorStores.ts
@@ -18,8 +18,8 @@ import {
 import { ExchangeType, ExchangeProductType } from '@/types/constants/enums';
 
 interface UseSelectorStoresProps {
-  defaultExchangeType?: ExchangeProductType;
-  onExchangeTypeChange?: (type: ExchangeProductType) => void;
+  defaultProductType?: ExchangeProductType;
+  onProductTypeChange?: (type: ExchangeProductType) => void;
 }
 
 /**
@@ -34,8 +34,8 @@ interface UseSelectorStoresProps {
  * @returns ストアのデータとアクション、取引タイプの状態と制御関数
  */
 export const useSelectorStores = ({
-  defaultExchangeType = 'spot',
-  onExchangeTypeChange
+  defaultProductType = 'spot',
+  onProductTypeChange
 }: UseSelectorStoresProps = {}) => {
   // SymbolSliceから状態とアクションを取得
   const filteredSymbols = useRootStore(selectFilteredSymbols);
@@ -45,42 +45,42 @@ export const useSelectorStores = ({
   const toggleFavorite = useRootStore(state => state.toggleFavorite);
   
   // 取引タイプの状態
-  const [exchangeType, setExchangeType] = useState<ExchangeProductType>(defaultExchangeType || 'spot');
+  const [productType, setProductType] = useState<ExchangeProductType>(defaultProductType || 'spot');
   
   // ExchangeProductTypeをExchangeTypeに変換するヘルパー関数
-  const toExchangeType = useCallback((productType: ExchangeProductType): ExchangeType => {
+  const toExchangeType = useCallback((pType: ExchangeProductType): ExchangeType => {
     // ここではデフォルトで'bitget'を使用するが、必要に応じてロジックを変更可能
     return 'bitget';
   }, []);
 
   // 取引タイプ変更のハンドラー
-  const handleExchangeTypeChange = (value: string) => {
+  const handleProductTypeChange = (value: string) => {
     if (value !== 'spot' && value !== 'futures') {
       console.warn(`Invalid exchange product type: ${value}, defaulting to 'spot'`);
       value = 'spot';
     }
     const newType = value as ExchangeProductType;
-    setExchangeType(newType);
+    setProductType(newType);
     
     // ExchangeProductTypeをExchangeTypeに変換してfetchSymbolsを呼び出す
     const exchangeTypeForFetch = toExchangeType(newType);
     fetchSymbols(exchangeTypeForFetch);
     
     // 外部コールバックがあれば呼び出す
-    if (onExchangeTypeChange) {
-      onExchangeTypeChange(newType);
+    if (onProductTypeChange) {
+      onProductTypeChange(newType);
     }
   };
   
   // 初回レンダリング時に銘柄を取得
   useEffect(() => {
-    const exchangeTypeForFetch = toExchangeType(exchangeType);
+    const exchangeTypeForFetch = toExchangeType(productType);
     fetchSymbols(exchangeTypeForFetch);
-  }, [fetchSymbols, exchangeType, toExchangeType]);
+  }, [fetchSymbols, productType, toExchangeType]);
   
   // データフェッチを再試行する関数
   const retryFetch = () => {
-    const exchangeTypeForFetch = toExchangeType(exchangeType);
+    const exchangeTypeForFetch = toExchangeType(productType);
     fetchSymbols(exchangeTypeForFetch);
   };
   
@@ -99,9 +99,9 @@ export const useSelectorStores = ({
     },
     
     // 取引タイプ関連
-    exchangeType: {
-      current: exchangeType,
-      handleChange: handleExchangeTypeChange
+    productType: {
+      current: productType,
+      handleChange: handleProductTypeChange
     }
   };
 };

--- a/hooks/symbol/selector/useSymbolSelectorLogic.ts
+++ b/hooks/symbol/selector/useSymbolSelectorLogic.ts
@@ -35,10 +35,10 @@ export const useSymbolSelectorLogic = ({
   const toggleFavorite = useRootStore(state => state.toggleFavorite);
   const fetchSymbols = useRootStore(state => state.fetchSymbols);
   const setProductType = useRootStore(state => state.setProductType);
-  const currentExchangeType = useRootStore(state => state.exchangeType);
+  const currentProductType = useRootStore(state => state.exchangeType);
 
   // 取引タイプの変更ハンドラー
-  const handleExchangeTypeChange = useCallback(
+  const handleProductTypeChange = useCallback(
     (type: ExchangeType) => {
       setProductType(type);
       if (onExchangeTypeChange) {
@@ -50,20 +50,20 @@ export const useSymbolSelectorLogic = ({
 
   // 再試行ハンドラー
   const retryFetch = useCallback(() => {
-    fetchSymbols(currentExchangeType);
-  }, [fetchSymbols, currentExchangeType]);
+    fetchSymbols(currentProductType);
+  }, [fetchSymbols, currentProductType]);
 
   // デフォルトの取引タイプが指定されていれば設定
   useEffect(() => {
-    if (defaultExchangeType && defaultExchangeType !== currentExchangeType) {
+    if (defaultExchangeType && defaultExchangeType !== currentProductType) {
       setProductType(defaultExchangeType);
     }
-  }, [defaultExchangeType, currentExchangeType, setProductType]);
+  }, [defaultExchangeType, currentProductType, setProductType]);
 
   return {
     symbols: { filteredSymbols: symbols, isLoading, error },
     actions: { toggleFavorite, retryFetch },
-    exchangeType: { current: currentExchangeType, handleChange: handleExchangeTypeChange }
+    productType: { current: currentProductType, handleChange: handleProductTypeChange }
   };
 };
 


### PR DESCRIPTION
## Summary
- replace `ExchangeType` with `ProductType` in ExchangeTabs and adjust props
- rename product type props in AdvancedSelectorView and SymbolSelector
- update selector hooks to use `productType`

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest' and 'node')*
- `npm test` *(fails: Cannot find type definition file for 'jest' and 'node')*