### PR TITLE
Add service reset utilities

### DIFF
--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -532,6 +532,20 @@ export function subscribeKline(
 }
 ```
 
+### 8.2 サービスリセット
+
+テストを実行する際はシングルトンで保持しているサービス状態を初期化する必要があり
+ます。`services/reset.ts` で提供される `resetAllServices` ヘルパーを利用すると、
+キャッシュやWebSocket接続をまとめてクリアできます。
+
+```typescript
+import { resetAllServices } from '@/services/reset'
+
+beforeEach(() => {
+  resetAllServices()
+})
+```
+
 #### 5.3.2 WebSocketとRESTAPIのハイブリッド機能
 
 `dataFetchService.ts`は、WebSocketとRESTAPIを組み合わせたハイブリッドアプローチを提供します：

--- a/services/api/data-source-factory.ts
+++ b/services/api/data-source-factory.ts
@@ -82,10 +82,32 @@ export class DataSourceFactory implements IDataSourceFactory {
     
     // クライアントをキャッシュに保存
     this.restClients.set(exchange, client);
-    
+
     return client;
+  }
+
+  /**
+   * 保持しているクライアントをすべて破棄
+   */
+  public reset(): void {
+    this.wsClients.forEach((client) => {
+      try {
+        client.disconnect();
+      } catch (error) {
+        logger.warn('WebSocket client disconnect failed', { error });
+      }
+    });
+    this.wsClients.clear();
+    this.restClients.clear();
   }
 }
 
 // シングルトンインスタンスをエクスポート
 export const dataSourceFactory = new DataSourceFactory();
+
+/**
+ * DataSourceFactoryインスタンスをリセット
+ */
+export function resetDataSourceFactory(): void {
+  dataSourceFactory.reset();
+}

--- a/services/cache/service.ts
+++ b/services/cache/service.ts
@@ -157,6 +157,14 @@ class CacheService {
       count: size
     });
   }
+
+  /**
+   * サービスをリセット
+   * 全キャッシュを削除します
+   */
+  reset(): void {
+    this.clear();
+  }
   
   /**
    * キャッシュのサイズを取得
@@ -196,3 +204,10 @@ class CacheService {
 
 // シングルトンインスタンスをエクスポート
 export const cacheService = new CacheService();
+
+/**
+ * サービスインスタンスをリセット
+ */
+export function resetCacheService(): void {
+  cacheService.reset();
+}

--- a/services/ccxws/client.ts
+++ b/services/ccxws/client.ts
@@ -517,3 +517,10 @@ export function getCCXWSClient(): CCXWSClient {
   }
   return ccxwsClientInstance;
 }
+
+/**
+ * シングルトンインスタンスをリセット
+ */
+export function resetCCXWSClient(): void {
+  ccxwsClientInstance = null;
+}

--- a/services/data/chart-data-service.ts
+++ b/services/data/chart-data-service.ts
@@ -223,6 +223,15 @@ class ChartDataService extends EventEmitter implements IChartDataService {
     // キャッシュからチャートデータのキャッシュを削除
     cacheService.clearByPattern(/^chart_/);
   }
+
+  /**
+   * サービス状態をリセット
+   * すべての購読を解除し、内部クライアントを破棄します
+   */
+  reset(): void {
+    this.unsubscribeAllKlines();
+    this.bitgetApiClient = null;
+  }
 }
 
 /**
@@ -264,6 +273,9 @@ export function getChartDataService(): ChartDataService {
 
 // テスト用にシングルトンインスタンスをリセットする関数
 export function resetChartDataServiceForTesting(): void {
+  if (chartDataServiceInstance) {
+    chartDataServiceInstance.reset();
+  }
   chartDataServiceInstance = null;
 }
 

--- a/services/data/factory.ts
+++ b/services/data/factory.ts
@@ -7,8 +7,15 @@
 
 import { IOrderBookService, IChartDataService } from './interfaces';
 import { getChartDataService, resetChartDataServiceForTesting } from './chart-data-service';
-import { orderBookService } from './order-book-service';
+import { orderBookService, resetOrderBookService } from './order-book-service';
 import { dataFetchService } from './dataFetchService';
+import { resetCacheService } from '../cache/service';
+import { resetDataSourceFactory } from '../api/data-source-factory';
+import { resetCCXWSClient } from '../ccxws/client';
+import { resetWebSocketClientForTesting } from '../socket/websocket-client';
+import { resetSubscriptionManagerForTesting } from '../socket/subscription-manager';
+import { resetBitgetIntegrationForTesting } from '../socket/bitget-integration';
+import { resetInstances as resetSocketInstances } from '../socket/factory';
 
 // モックモード判定
 const isMockMode = process.env.MOCK_MODE === 'true';
@@ -42,5 +49,12 @@ export function getDataFetchServiceFactory() {
  */
 export function resetAllServicesForTesting(): void {
   resetChartDataServiceForTesting();
-  // 他のサービスのリセット関数があれば追加
+  resetOrderBookService();
+  resetCacheService();
+  resetDataSourceFactory();
+  resetCCXWSClient();
+  resetSubscriptionManagerForTesting();
+  resetBitgetIntegrationForTesting();
+  resetWebSocketClientForTesting();
+  resetSocketInstances();
 }

--- a/services/data/order-book-service.ts
+++ b/services/data/order-book-service.ts
@@ -255,7 +255,15 @@ class OrderBookService extends EventEmitter implements IOrderBookService {
     // 購読リストをクリア
     this.subscriptions.clear();
   }
-  
+
+  /**
+   * サービス状態をリセット
+   */
+  reset(): void {
+    this.unsubscribeAllOrderBooks();
+    this.bitgetApiClient = null;
+  }
+
   /**
    * すべての購読を解除
    * @deprecated 代わりにunsubscribeAllOrderBooksを使用してください
@@ -268,3 +276,10 @@ class OrderBookService extends EventEmitter implements IOrderBookService {
 
 // シングルトンインスタンスをエクスポート
 export const orderBookService = new OrderBookService();
+
+/**
+ * サービスインスタンスをリセット
+ */
+export function resetOrderBookService(): void {
+  orderBookService.reset();
+}

--- a/services/index.ts
+++ b/services/index.ts
@@ -26,5 +26,6 @@ export * from './api/common/environment';
 export * from './cache';
 export * from './history';
 export * from './data';
+export * from './reset';
 
 // 古いdataFetchServiceのエクスポートは削除されました

--- a/services/reset.ts
+++ b/services/reset.ts
@@ -1,0 +1,24 @@
+import { resetChartDataServiceForTesting } from './data/chart-data-service';
+import { resetOrderBookService } from './data/order-book-service';
+import { resetCacheService } from './cache/service';
+import { resetDataSourceFactory } from './api/data-source-factory';
+import { resetCCXWSClient } from './ccxws/client';
+import { resetInstances as resetSocketInstances } from './socket/factory';
+import { resetWebSocketClientForTesting } from './socket/websocket-client';
+import { resetSubscriptionManagerForTesting } from './socket/subscription-manager';
+import { resetBitgetIntegrationForTesting } from './socket/bitget-integration';
+
+/**
+ * すべてのサービスを初期状態にリセットするヘルパー
+ */
+export function resetAllServices(): void {
+  resetChartDataServiceForTesting();
+  resetOrderBookService();
+  resetCacheService();
+  resetDataSourceFactory();
+  resetCCXWSClient();
+  resetWebSocketClientForTesting();
+  resetSubscriptionManagerForTesting();
+  resetBitgetIntegrationForTesting();
+  resetSocketInstances();
+}

--- a/services/socket/bitget-integration.ts
+++ b/services/socket/bitget-integration.ts
@@ -98,3 +98,11 @@ export function getBitgetIntegration(): BitgetIntegration {
   }
   return bitgetIntegrationInstance;
 }
+
+/**
+ * テスト用にシングルトンをリセット
+ */
+export function resetBitgetIntegrationForTesting(): void {
+  bitgetIntegrationInstance?.disconnectApiClient();
+  bitgetIntegrationInstance = null;
+}

--- a/services/socket/subscription-manager.ts
+++ b/services/socket/subscription-manager.ts
@@ -524,3 +524,10 @@ export function getSubscriptionManager(webSocketClient?: IWebSocketClient): Subs
   }
   return subscriptionManagerInstance;
 }
+
+/**
+ * テスト用にシングルトンをリセット
+ */
+export function resetSubscriptionManagerForTesting(): void {
+  subscriptionManagerInstance = null;
+}


### PR DESCRIPTION
## Summary
- add singleton reset helpers across services
- provide `resetAllServices` top-level util
- document reset helper for test setups

## Testing
- `npm run typecheck:test` *(fails: Cannot find type definition file for 'jest')*
- `npm test` *(fails: Cannot find type definition file for 'jest')*
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest')*
- `npm run lint` *(fails: next not found)*