### PR TITLE
Fix property name in MessageListWrapper test

### DIFF
--- a/components/chat/window/ui/__tests__/MessageListWrapper.test.tsx
+++ b/components/chat/window/ui/__tests__/MessageListWrapper.test.tsx
@@ -24,7 +24,7 @@ describe('MessageListWrapper', () => {
   const mockPendingEntry: Partial<OpenEntry> = {
     id: 'entry1',
     symbol: 'BTC-USD',
-    entryPrice: 50000,
+    price: 50000,
     side: 'buy'
   };
   


### PR DESCRIPTION
## Summary
- correct mock entry field name in MessageListWrapper test

## Testing
- `npm test -- components/chat/window/ui/__tests__/MessageListWrapper.test.tsx` *(fails: cannot find type definition file for 'jest' and 'node')*