### PR TITLE
Fix chat slice creation

### DIFF
--- a/store/rootStore.ts
+++ b/store/rootStore.ts
@@ -288,7 +288,8 @@ export const useRootStore = create<RootStore>()(
           
           const chatSlice = createChatSlice(
             (fn) => immerSet<ChatSliceState>(fn),
-            () => getState<ChatSliceState>()
+            () => getState<ChatSliceState>(),
+            api
           );
           
           const uiSlice = createUISlice(


### PR DESCRIPTION
## Summary
- pass `api` to `createChatSlice` when initializing the chat slice

## Testing
- `npm test` *(fails: Cannot find type definition file for 'jest' and 'node')*