### PR TITLE
Remove deprecated logger module

### DIFF
--- a/.backup/index.ts
+++ b/.backup/index.ts
@@ -9,7 +9,7 @@
 
 import { BitgetRestClient } from '../api/bitget/rest-client';
 import { BitgetWebSocketClient as NewBitgetWebSocketClient } from '../api/bitget/websocket-client';
-import { logger } from '../../utils/logger';
+import { logger } from '../../utils/common';
 
 // BitgetApiClientのエクスポート
 import { BitgetApiClient } from '../bitgetApi';

--- a/__tests__/chart/dataSanitizer.test.ts
+++ b/__tests__/chart/dataSanitizer.test.ts
@@ -19,7 +19,7 @@ import { OHLCData } from '../../types/chart';
 import { jest } from '@jest/globals';
 
 // loggerをモック
-jest.mock('../../utils/logger', () => ({
+jest.mock('../../utils/common', () => ({
   logger: {
     warn: jest.fn(),
     error: jest.fn(),

--- a/__tests__/chart/useChartCore.test.ts
+++ b/__tests__/chart/useChartCore.test.ts
@@ -54,7 +54,7 @@ jest.mock('lightweight-charts', () => ({
 }));
 
 // ロガーをモック
-jest.mock('../../utils/logger', () => ({
+jest.mock('../../utils/common', () => ({
   logger: {
     warn: jest.fn(),
     error: jest.fn(),

--- a/__tests__/chart/useChartSectionInit.test.ts
+++ b/__tests__/chart/useChartSectionInit.test.ts
@@ -32,7 +32,7 @@ jest.mock('@/store/chart/data', () => ({
 }));
 
 // ロガーをモック
-jest.mock('@/utils/logger', () => ({
+jest.mock('@/utils/common/logger', () => ({
   logger: {
     info: jest.fn(),
     error: jest.fn(),
@@ -158,6 +158,6 @@ describe('useChartSectionInit', () => {
     result.current.fetchData();
     
     // エラーログが出力されることを検証
-    expect(require('@/utils/logger').logger.error).toHaveBeenCalled();
+    expect(require('@/utils/common/logger').logger.error).toHaveBeenCalled();
   });
 }); 

--- a/__tests__/chart/useIndicators.test.ts
+++ b/__tests__/chart/useIndicators.test.ts
@@ -38,7 +38,7 @@ jest.mock('@/components/chart/indicators', () => ({
 }));
 
 // ロガーをモック
-jest.mock('../../utils/logger', () => ({
+jest.mock('../../utils/common', () => ({
   logger: {
     warn: jest.fn(),
     error: jest.fn(),

--- a/__tests__/components/chat/section/hooks/useQuickCommands.test.ts
+++ b/__tests__/components/chat/section/hooks/useQuickCommands.test.ts
@@ -14,7 +14,7 @@ import { logger } from '@/utils/common';
 // lucide-reactモックは不要になったため削除
 
 // ロガーをモック
-jest.mock('@/utils/logger', () => ({
+jest.mock('@/utils/common/logger', () => ({
   logger: {
     info: jest.fn(),
   },

--- a/__tests__/components/chat/section/hooks/useQuickCommands.test.tsx
+++ b/__tests__/components/chat/section/hooks/useQuickCommands.test.tsx
@@ -19,7 +19,7 @@ jest.mock('lucide-react', () => ({
 }));
 
 // ロガーをモック
-jest.mock('@/utils/logger', () => ({
+jest.mock('@/utils/common/logger', () => ({
   logger: {
     info: jest.fn(),
   },

--- a/__tests__/hooks/chat/useQuickCommands.test.tsx
+++ b/__tests__/hooks/chat/useQuickCommands.test.tsx
@@ -31,7 +31,7 @@ const mockQuickCommands = [
 ];
 
 // ロガーのモック
-jest.mock('@/utils/logger', () => ({
+jest.mock('@/utils/common/logger', () => ({
   logger: {
     info: jest.fn(),
   },

--- a/__tests__/integration/data-flow/symbol-change-flow.test.ts
+++ b/__tests__/integration/data-flow/symbol-change-flow.test.ts
@@ -3,7 +3,7 @@
 
 import { changeSymbolTool } from '../../../src/mastra/tools/symbol-tools';
 import { useRootStore } from '../../../store/rootStore';
-import { logger } from '../../../utils/logger';
+import { logger } from '../../../utils/common';
 
 // モジュールをモック化
 jest.mock('../../../src/mastra/tools/symbol-tools', () => ({
@@ -24,7 +24,7 @@ jest.mock('../../../store/rootStore', () => ({
   },
 }));
 
-jest.mock('../../../utils/logger', () => ({
+jest.mock('../../../utils/common', () => ({
   logger: {
     info: jest.fn(),
     error: jest.fn(),

--- a/__tests__/services/api/bitget/rest-client.test.ts
+++ b/__tests__/services/api/bitget/rest-client.test.ts
@@ -9,11 +9,11 @@
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { BitgetRestClient } from '../../../../services/api/bitget/rest-client';
-import { logger } from '../../../../utils/logger';
+import { logger } from '../../../../utils/common';
 
 // モックの設定
 const mock = new MockAdapter(axios);
-jest.mock('../../../../utils/logger', () => ({
+jest.mock('../../../../utils/common', () => ({
   logger: {
     debug: jest.fn(),
     error: jest.fn(),

--- a/__tests__/services/data/chart-data-service.test.ts
+++ b/__tests__/services/data/chart-data-service.test.ts
@@ -10,7 +10,7 @@ import { BitgetApiClient } from '../../../services/api/bitget/client';
 import { chartDataService, getChartDataService, resetChartDataServiceForTesting } from '../../../services/data/chart-data-service';
 import { cacheService } from '../../../services/cache/service';
 import { getSocketService } from '../../../services/socket/index';
-import { logger } from '../../../utils/logger';
+import { logger } from '../../../utils/common';
 import { OHLCData } from '../../../types/chart';
 import { type ExchangeType, type ProductType } from '@/types/constants/enums';
 
@@ -30,7 +30,7 @@ const PRODUCT_TYPES = {
 jest.mock('../../../services/api/bitget/client');
 jest.mock('../../../services/cache/service');
 jest.mock('../../../services/socket/index');
-jest.mock('../../../utils/logger');
+jest.mock('../../../utils/common');
 
 // テスト用のモックデータ
 const mockOHLCData: OHLCData[] = [

--- a/__tests__/services/socket/bitget-integration.test.ts
+++ b/__tests__/services/socket/bitget-integration.test.ts
@@ -8,7 +8,7 @@
 import { BitgetIntegration } from '../../../services/socket/bitget-integration';
 import { BitgetApiClient } from '../../../services/api/bitget/client';
 import { ProductType } from '@/types/api';
-import { logger } from '../../../utils/logger';
+import { logger } from '../../../utils/common';
 
 // BitgetApiClientのモック
 jest.mock('../../../services/api/bitget/client', () => {
@@ -23,7 +23,7 @@ jest.mock('../../../services/api/bitget/client', () => {
   };
 });
 
-jest.mock('../../../utils/logger', () => ({
+jest.mock('../../../utils/common', () => ({
   logger: {
     info: jest.fn(),
     warn: jest.fn(),

--- a/__tests__/services/socket/socket-service.test.ts
+++ b/__tests__/services/socket/socket-service.test.ts
@@ -12,7 +12,7 @@ import { OrderBookData } from '../../../types/market';
 import { OHLCData } from '../../../types/chart';
 import { ProductType } from '@/types/api';
 import { BitgetApiClient } from '../../../services/api/bitget/client';
-import { logger } from '../../../utils/logger';
+import { logger } from '../../../utils/common';
 
 // モック
 const mockSocket = {
@@ -56,7 +56,7 @@ const mockBitgetIntegration: IBitgetIntegration = {
   disconnectApiClient: jest.fn()
 };
 
-jest.mock('../../../utils/logger', () => ({
+jest.mock('../../../utils/common', () => ({
   logger: {
     info: jest.fn(),
     warn: jest.fn(),

--- a/__tests__/services/socket/subscription-manager.test.ts
+++ b/__tests__/services/socket/subscription-manager.test.ts
@@ -19,7 +19,7 @@ jest.mock('../../../services/socket/websocket-client', () => ({
   resetWebSocketClientForTesting: jest.fn()
 }));
 
-jest.mock('../../../utils/logger', () => ({
+jest.mock('../../../utils/common', () => ({
   logger: {
     info: jest.fn(),
     warn: jest.fn(),
@@ -29,7 +29,7 @@ jest.mock('../../../utils/logger', () => ({
 }));
 
 // モックをインポート
-const { logger } = require('../../../utils/logger');
+const { logger } = require('../../../utils/common');
 
 // モック
 const mockSocket = {
@@ -48,7 +48,7 @@ const mockWebSocketClient: IWebSocketClient = {
   scheduleReconnect: jest.fn()
 };
 
-jest.mock('../../../utils/logger', () => ({
+jest.mock('../../../utils/common', () => ({
   logger: {
     info: jest.fn(),
     warn: jest.fn(),

--- a/__tests__/services/socket/websocket-client.test.ts
+++ b/__tests__/services/socket/websocket-client.test.ts
@@ -9,7 +9,7 @@
 import { Socket } from 'socket.io-client';
 import { WebSocketClient } from '../../../services/socket/websocket-client';
 import { SocketCore } from '../../../services/socket/core';
-import { logger } from '../../../utils/logger';
+import { logger } from '../../../utils/common';
 
 // モックの設定
 jest.mock('../../../services/socket/core', () => {
@@ -22,7 +22,7 @@ jest.mock('../../../services/socket/core', () => {
   };
 });
 
-jest.mock('../../../utils/logger', () => {
+jest.mock('../../../utils/common', () => {
   return {
     logger: {
       info: jest.fn(),

--- a/__tests__/unit/tools/instrument-type-tools.test.ts
+++ b/__tests__/unit/tools/instrument-type-tools.test.ts
@@ -3,12 +3,12 @@
 // Cascade: Corrected import path for ExchangeType.
 
 import { changeInstrumentTypeTool } from '../../../src/mastra/tools/instrument-type-tools';
-import { logger } from '../../../utils/logger';
+import { logger } from '../../../utils/common';
 import fetch from 'node-fetch'; // Import to mock
 import { ExchangeType, ProductType } from '@/types/api';
 
 // Mock logger
-jest.mock('../../../utils/logger', () => ({
+jest.mock('../../../utils/common', () => ({
   logger: {
     info: jest.fn(),
     error: jest.fn(),

--- a/__tests__/unit/tools/symbol-tools.test.ts
+++ b/__tests__/unit/tools/symbol-tools.test.ts
@@ -3,12 +3,12 @@
 // Cascade: Mocked node-fetch, updated error case assertions, adapted mock responses.
 
 import { changeSymbolTool } from '../../../src/mastra/tools/symbol-tools';
-import { logger } from '../../../utils/logger';
+import { logger } from '../../../utils/common';
 import fetch from 'node-fetch'; // Import to mock
 import { ExchangeType, ProductType } from '@/types/api';
 
 // Mock logger
-jest.mock('../../../utils/logger', () => ({
+jest.mock('../../../utils/common', () => ({
   logger: {
     info: jest.fn(),
     error: jest.fn(),

--- a/__tests__/unit/utils/socketClient.test.ts
+++ b/__tests__/unit/utils/socketClient.test.ts
@@ -4,7 +4,7 @@ import { Timeframe } from '../../../types/chart';
 import type { Socket } from 'socket.io-client'; // Socket 型をインポート (DisconnectReason を削除)
 
 // logger のモック
-jest.mock('../../../utils/logger', () => ({
+jest.mock('../../../utils/common', () => ({
   logger: {
     info: jest.fn(),
     warn: jest.fn(),
@@ -144,7 +144,7 @@ describe('socketClient', () => {
     // jest.clearAllMocks(); // これも追加してみる
 
     // Logger のモックとスパイの設定
-    const loggerModule = require('../../../utils/logger');
+    const loggerModule = require('../../../utils/common');
     logger = loggerModule.logger; // describe スコープの logger に代入
     jest.spyOn(loggerModule.logger, 'info').mockImplementation(jest.fn());
     jest.spyOn(loggerModule.logger, 'warn').mockImplementation(jest.fn());

--- a/server/bitgetWebSocketManager.ts
+++ b/server/bitgetWebSocketManager.ts
@@ -12,7 +12,7 @@
 import WebSocket from 'ws';
 import { EventEmitter } from 'events';
 import { ExchangeType, ExchangeProductType } from '@/types/constants/enums';
-import { logger } from '@/utils/logger';
+import { logger } from '@/utils/common';
 import { getApiConfig } from '../services/api/common/environment';
 import { toBitget, fromBitget } from '../utils/timeframe';
 import { toProductType, safeExchangeType, safeProductType } from '@/utils/exchangeTypeUtils';

--- a/services/api/bitget/client.new.ts
+++ b/services/api/bitget/client.new.ts
@@ -15,7 +15,7 @@ import { OrderBookData } from '../../../types/market';
 import { IRestApiClient, IWebSocketClient } from '../interfaces';
 import { BitgetApiClientOptions, IBitgetApiClient } from './interfaces';
 import { getApiConfig, IS_DEV } from '../common/environment';
-import { logger } from '../../../utils/logger';
+import { logger } from '../../../utils/common';
 import { formatSymbol } from './utils';
 import { BitgetRestClient } from './rest-client';
 import { BitgetWebSocketClient } from './ws-client';

--- a/services/api/bitget/client.ts
+++ b/services/api/bitget/client.ts
@@ -15,7 +15,7 @@ import { OrderBookData } from '../../../types/market';
 import { IRestApiClient, IWebSocketClient } from '../interfaces';
 import { BitgetApiClientOptions, IBitgetApiClient } from './interfaces';
 import { getApiConfig, IS_DEV } from '../common/environment';
-import { logger } from '../../../utils/logger';
+import { logger } from '../../../utils/common';
 import { formatSymbol } from './utils';
 import { BitgetRestClient } from './rest-client';
 import { BitgetWebSocketClient } from './ws-client';

--- a/services/api/bitget/rest-client.ts
+++ b/services/api/bitget/rest-client.ts
@@ -14,7 +14,7 @@ import axios, { AxiosError } from 'axios';
 import { ExchangeType, ExchangeProductType } from '@/types/api';
 import { OHLCData, Timeframe, OrderBookData } from '../../../types/chart';
 import { IRestApiClient } from '../interfaces';
-import { logger } from '../../../utils/logger';
+import { logger } from '../../../utils/common';
 import { safeExchangeType, safeProductType } from '../../../utils/exchangeTypeUtils';
 
 /* --- ① symbol を API 仕様に合わせて正規化 --- */

--- a/services/api/bitget/utils.ts
+++ b/services/api/bitget/utils.ts
@@ -10,7 +10,7 @@
  */
 
 import { IS_BROWSER } from '../common/environment';
-import { logger } from '../../../utils/logger';
+import { logger } from '../../../utils/common';
 
 /**
  * 先物取引で利用できない可能性が高い銘柄のパターン

--- a/services/api/bitget/websocket-client.ts
+++ b/services/api/bitget/websocket-client.ts
@@ -11,7 +11,7 @@
 import { EventEmitter } from 'events';
 import { Timeframe } from '../../../types/chart';
 import { IWebSocketClient } from '../interfaces';
-import { logger } from '../../../utils/logger';
+import { logger } from '../../../utils/common';
 
 // 環境検出
 const isNodeJS = typeof window === 'undefined';

--- a/services/api/chart-data-service.new.ts
+++ b/services/api/chart-data-service.new.ts
@@ -14,7 +14,7 @@ import { ExchangeType } from '@/types/api';
 import { OHLCData, OrderBookData, Timeframe } from '../../types/chart';
 import { IChartDataService } from './interfaces';
 import { dataSourceFactory } from './data-source-factory';
-import { logger } from '../../utils/logger';
+import { logger } from '../../utils/common';
 import { normalizeSymbol } from '../../utils/formatters';
 
 // キャッシュサービスのインポート

--- a/services/api/chart-data-service.ts
+++ b/services/api/chart-data-service.ts
@@ -14,7 +14,7 @@ import { ExchangeType } from '@/types/api';
 import { OHLCData, OrderBookData, Timeframe } from '../../types/chart';
 import { IChartDataService } from './interfaces';
 import { dataSourceFactory } from './data-source-factory';
-import { logger } from '../../utils/logger';
+import { logger } from '../../utils/common';
 import { normalizeSymbol } from '../../utils/formatters';
 
 // キャッシュサービスのインポート

--- a/services/api/data-source-factory.ts
+++ b/services/api/data-source-factory.ts
@@ -11,7 +11,7 @@
 import { IDataSourceFactory, IRestApiClient, IWebSocketClient } from './interfaces';
 import { BitgetWebSocketClient } from './bitget/websocket-client';
 import { BitgetRestClient } from './bitget/rest-client';
-import { logger } from '../../utils/logger';
+import { logger } from '../../utils/common';
 
 /**
  * データソースファクトリー

--- a/services/cache/cacheService.ts
+++ b/services/cache/cacheService.ts
@@ -6,7 +6,7 @@
  */
 
 import { ICacheService, CacheStats, CacheEntry } from './cacheTypes';
-import { logger } from '../../utils/logger';
+import { logger } from '../../utils/common';
 
 export class CacheService implements ICacheService {
   private cache = new Map<string, CacheEntry<any>>();

--- a/services/cache/service.ts
+++ b/services/cache/service.ts
@@ -7,7 +7,7 @@
  * キャッシュエントリには有効期限とソース情報を付加できます。
  */
 
-import { logger } from '../../utils/logger';
+import { logger } from '../../utils/common';
 
 // キャッシュエントリの型定義
 interface CacheEntry<T> {

--- a/services/data/chart-data-service.ts
+++ b/services/data/chart-data-service.ts
@@ -11,7 +11,7 @@ import { BitgetApiClient } from '../api/bitget/client';
 import { IChartDataService } from './interfaces';
 import { OHLCData, Timeframe } from '../../types/chart';
 import { ExchangeType } from '@/types/api';
-import { logger } from '../../utils/logger';
+import { logger } from '../../utils/common';
 import { normalizeSymbol } from '../../utils/formatters';
 import { getSocketService } from '../socket/index';
 import { cacheService } from '../cache/service';

--- a/services/data/dataFetchService.ts
+++ b/services/data/dataFetchService.ts
@@ -18,7 +18,7 @@ import { BitgetApiClient } from '../api/bitget/client';
 import { IDataFetchService } from './dataFetchTypes';
 import { OHLCData, Timeframe } from '../../types/chart';
 import { ExchangeType } from '@/types/api';
-import { logger } from '../../utils/logger';
+import { logger } from '../../utils/common';
 import { normalizeSymbol } from '../../utils/formatters';
 import { getSocketService } from '../socket/service';
 import { cacheService } from '../cache/service';

--- a/services/data/order-book-service.ts
+++ b/services/data/order-book-service.ts
@@ -11,7 +11,7 @@ import { BitgetApiClient } from '../api/bitget/client';
 import { IOrderBookService } from '../api/interfaces';
 import { OrderBookData } from '../../types/chart';
 import { ExchangeType } from '@/types/api';
-import { logger } from '../../utils/logger';
+import { logger } from '../../utils/common';
 import { normalizeSymbol } from '../../utils/formatters';
 import { getSocketService } from '../socket/service';
 import { cacheService } from '../cache/service';

--- a/services/socket/bitget-integration.ts
+++ b/services/socket/bitget-integration.ts
@@ -8,7 +8,7 @@
 
 import { ProductType } from '@/types/api';
 import { BitgetApiClient } from '../api/bitget/client';
-import { logger } from '../../utils/logger';
+import { logger } from '../../utils/common';
 import { IBitgetIntegration } from './interfaces';
 
 /**

--- a/services/socket/factory.ts
+++ b/services/socket/factory.ts
@@ -14,7 +14,7 @@ import { getBitgetIntegration } from './bitget-integration';
 import { MockSocketService, getMockSocketService } from './mock-service';
 // 相対パスでインポート
 import { SocketService } from './socket-service';
-import { logger } from '../../utils/logger';
+import { logger } from '../../utils/common';
 import { SocketCore } from './core';
 
 // シングルトンインスタンス

--- a/services/socket/mock-service.ts
+++ b/services/socket/mock-service.ts
@@ -10,7 +10,7 @@ import { EventEmitter } from 'events';
 import { OrderBookData, OrderBookEntry } from '@/types/common/orderbook';
 import { OHLCData, Timeframe } from '../../types/chart';
 import { ProductType } from '@/types/api';
-import { logger } from '../../utils/logger';
+import { logger } from '../../utils/common';
 import { ISocketService } from './interfaces';
 
 /**

--- a/services/socket/service.ts
+++ b/services/socket/service.ts
@@ -8,7 +8,7 @@ import { Socket } from 'socket.io-client';
 import { OrderBookData } from '../../types/market';
 import { OHLCData, Timeframe } from '../../types/chart';
 import { ExchangeType } from '@/types/api';
-import { logger } from '../../utils/logger';
+import { logger } from '../../utils/common';
 import { ISocketService } from './interfaces';
 
 /**

--- a/services/socket/socket-service.ts
+++ b/services/socket/socket-service.ts
@@ -11,7 +11,7 @@ import { OrderBookData } from '../../types/market';
 import { OHLCData, Timeframe } from '../../types/chart';
 import { ProductType } from '@/types/api';
 import { BitgetApiClient } from '../api/bitget/client';
-import { logger } from '../../utils/logger';
+import { logger } from '../../utils/common';
 import { 
   ISocketService, 
   IWebSocketClient, 

--- a/services/socket/subscription-manager.ts
+++ b/services/socket/subscription-manager.ts
@@ -11,7 +11,7 @@ import { OrderBookData } from '../../types/market';
 import { OHLCData, Timeframe } from '../../types/chart';
 import { ProductType } from '@/types/api';
 import { normalizeSymbol } from '../../lib/utils';
-import { logger } from '../../utils/logger';
+import { logger } from '../../utils/common';
 import { ISubscriptionManager, IWebSocketClient } from './interfaces';
 import { getWebSocketClient } from './websocket-client';
 

--- a/store/symbol/actions.ts
+++ b/store/symbol/actions.ts
@@ -5,7 +5,7 @@
 // 更新: 2025-10-09 - S-9.2フェーズ: createIdGenerator関数のエラーを修正
 
 import { produce } from 'immer';
-import { logger } from '@/utils/logger';
+import { logger } from '@/utils/common';
 import { type ExchangeType, type ProductType } from '@/types/constants/enums';
 import { toProductType, isValidExchangeType, isValidProductType } from '@/utils/exchange';
 import { symbolService } from '@/services/symbol';

--- a/utils/logger.ts
+++ b/utils/logger.ts
@@ -1,8 +1,0 @@
-/**
- * @deprecated このファイルは utils/common/logger.ts に移動しました。
- * 新しい場所から import してください。
- * 例: import { logger } from '@/utils/common';
- */
-
-export { logger } from './common';
-export { default } from './common/logger'; 


### PR DESCRIPTION
## Summary
- delete `utils/logger.ts`
- update imports pointing to the old logger module
- point Jest mocks to new logger location

## Testing
- `npm test` *(fails: Cannot find type definition file for 'jest')*