### PR TITLE
Refactor chat interaction logic

### DIFF
--- a/__tests__/hooks/chat/useEntryManager.test.tsx
+++ b/__tests__/hooks/chat/useEntryManager.test.tsx
@@ -1,0 +1,77 @@
+import { renderHook, act } from '@testing-library/react'
+import { useEntryManager } from '@/hooks/chat'
+import type { Entry } from '@/types/entry'
+
+const setPendingEntry = jest.fn()
+const executeEntry = jest.fn()
+const setActiveTab = jest.fn()
+const setMessages = jest.fn()
+
+const mockProposal = { proposalType: 'buy', price: 100 }
+const useRootStoreMock = jest.fn(selector => selector({ latestProposal: mockProposal }))
+
+jest.mock('@/store', () => ({
+  useRootStore: (selector: any) => useRootStoreMock(selector),
+  selectLatestProposal: (state: any) => state.latestProposal,
+}))
+
+jest.mock('@/hooks/chat/utils', () => ({
+  getCurrentUserId: () => 'user',
+}))
+
+describe('useEntryManager', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('handleAIProposalQuery sets entry and switches tab', () => {
+    const { result } = renderHook(() =>
+      useEntryManager({
+        pendingEntry: null,
+        setPendingEntry,
+        executeEntry,
+        setActiveTab,
+        messages: [],
+        setMessages,
+      })
+    )
+
+    act(() => {
+      result.current.handleAIProposalQuery()
+    })
+
+    expect(setPendingEntry).toHaveBeenCalled()
+    expect(setActiveTab).toHaveBeenCalledWith('chart')
+  })
+
+  test('handleProceedWithEntry executes entry', () => {
+    const entry: Entry = {
+      id: '1',
+      userId: 'user',
+      side: 'buy',
+      symbol: 'BTC',
+      price: 1,
+      time: '',
+      status: 'open',
+    }
+
+    const { result } = renderHook(() =>
+      useEntryManager({
+        pendingEntry: entry,
+        setPendingEntry,
+        executeEntry,
+        setActiveTab,
+        messages: [],
+        setMessages,
+      })
+    )
+
+    act(() => {
+      result.current.handleProceedWithEntry()
+    })
+
+    expect(executeEntry).toHaveBeenCalled()
+    expect(setMessages).toHaveBeenCalled()
+  })
+})
+

--- a/__tests__/hooks/chat/useSampleResponses.test.tsx
+++ b/__tests__/hooks/chat/useSampleResponses.test.tsx
@@ -1,0 +1,59 @@
+import { renderHook, act } from '@testing-library/react'
+import { useSampleResponses } from '@/hooks/chat'
+
+const setMessages = jest.fn()
+const setPendingEntry = jest.fn()
+const setIsSearching = jest.fn()
+const submit = jest.fn()
+
+jest.mock('@/hooks/chat/utils', () => ({
+  getCurrentUserId: () => 'user',
+}))
+
+describe('useSampleResponses', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('triggers sample entry point response', () => {
+    const { result } = renderHook(() =>
+      useSampleResponses({
+        input: 'Entry Point please',
+        messages: [],
+        setMessages,
+        setPendingEntry,
+        setIsSearching,
+        conversationId: undefined,
+        submit,
+      })
+    )
+
+    act(() => {
+      result.current.handleSubmit({ preventDefault: jest.fn() } as any)
+    })
+
+    expect(setMessages).toHaveBeenCalled()
+    expect(setPendingEntry).toHaveBeenCalled()
+  })
+
+  test('falls back to submit when conversationId exists', () => {
+    const { result } = renderHook(() =>
+      useSampleResponses({
+        input: 'hello',
+        messages: [],
+        setMessages,
+        setPendingEntry,
+        setIsSearching,
+        conversationId: 'abc',
+        submit,
+      })
+    )
+
+    act(() => {
+      result.current.handleSubmit({ preventDefault: jest.fn() } as any)
+    })
+
+    expect(submit).toHaveBeenCalled()
+  })
+})
+

--- a/__tests__/hooks/chat/useStreamingMessages.test.tsx
+++ b/__tests__/hooks/chat/useStreamingMessages.test.tsx
@@ -1,0 +1,37 @@
+import { renderHook } from '@testing-library/react'
+import { useStreamingMessages } from '@/hooks/chat'
+import type { ExtendedMessage } from '@/types/chat/base'
+
+const addMessage = jest.fn()
+const updateMessage = jest.fn()
+
+jest.mock('@/store', () => ({
+  useRootStore: {
+    getState: () => ({
+      addMessage,
+      updateMessage,
+    }),
+  },
+}))
+
+describe('useStreamingMessages', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('adds and updates streaming message', () => {
+    const messages: ExtendedMessage[] = [
+      { id: '1', role: 'assistant', content: 'hi' },
+    ]
+    const { rerender } = renderHook(
+      ({ isLoading, msgs }) => useStreamingMessages(isLoading, msgs),
+      { initialProps: { isLoading: true, msgs: messages } }
+    )
+
+    expect(addMessage).toHaveBeenCalledTimes(1)
+
+    rerender({ isLoading: false, msgs: messages })
+    expect(updateMessage).toHaveBeenCalledWith(expect.any(String), { isStreaming: false })
+  })
+})
+

--- a/hooks/chat/index.ts
+++ b/hooks/chat/index.ts
@@ -21,4 +21,7 @@ export { default as useChatWindowStores } from '@/components/chat/window/hooks/u
 export { default as useAutoScroll } from '@/hooks/ui/useAutoScroll';
 
 // useChatInteractionフックのエクスポート
-export { useChatInteraction } from './useChatInteraction'; 
+export { useChatInteraction } from './useChatInteraction';
+export { useStreamingMessages } from './useStreamingMessages';
+export { useSampleResponses } from './useSampleResponses';
+export { useEntryManager } from './useEntryManager';

--- a/hooks/chat/useChatInteraction.ts
+++ b/hooks/chat/useChatInteraction.ts
@@ -20,14 +20,17 @@
 
 "use client"
 
-import { useState, useEffect, useRef, useCallback } from "react"
+import { useState, useEffect } from "react"
 import { useChat } from "ai/react"
-import { useRootStore, selectLatestProposal } from "@/store"
-import type { Entry, OpenEntry, TradeSide } from "@/types/entry"
-import type { ExtendedMessage, ProposalType } from "@/types/chat/base"
+import type { Entry, OpenEntry } from "@/types/entry"
+import type { ExtendedMessage } from "@/types/chat/base"
 import type { ChangeEvent, FormEvent } from "react"
 import type { Message } from "ai"
 import { v4 } from "uuid"
+import { useStreamingMessages } from "./useStreamingMessages"
+import { useSampleResponses } from "./useSampleResponses"
+import { useEntryManager } from "./useEntryManager"
+import { getCurrentUserId } from "./utils"
 
 interface UseChatInteractionProps {
   ohlcData?: any[]
@@ -130,53 +133,8 @@ Would you like to enter a long position at the current price of $60,500?`,
     },
   })
 
-  // ストリーミング中のメッセージを処理するための状態と参照
-  const streamingMessageIdRef = useRef<string | null>(null);
-  
-  // isLoadingがtrueの場合、AIからの応答がストリーミング中と判断
-  // originalMessagesの変更を監視して、最後のメッセージが更新されたらそれを表示
-  useEffect(() => {
-    if (isLoading && originalMessages.length > 0) {
-      // 最後のメッセージがAIのメッセージであれば、それはストリーミング中のメッセージ
-      const lastMessage = originalMessages[originalMessages.length - 1];
-      if (lastMessage.role === 'assistant') {
-        // ストリーミングメッセージIDを保存または更新
-        if (!streamingMessageIdRef.current) {
-          // 新しいストリーミングメッセージの場合、IDを生成して保存
-          streamingMessageIdRef.current = `streaming-${Date.now()}`;
-          
-          // 新しいメッセージをストアに追加
-          const streamingMessage: ExtendedMessage = {
-            id: streamingMessageIdRef.current,
-            role: 'assistant',
-            content: lastMessage.content,
-            isStreaming: true, // ストリーミング中であることを示すフラグを追加
-          };
-          
-          // useChatStoreをuseRootStoreに変更
-          useRootStore.getState().addMessage(streamingMessage);
-        } else {
-          // 既存のストリーミングメッセージを更新
-          // useChatStoreをuseRootStoreに変更
-          useRootStore.getState().updateMessage(
-            streamingMessageIdRef.current,
-            {
-              content: lastMessage.content,
-              isStreaming: true // ストリーミング中であることを示すフラグを更新
-            }
-          );
-        }
-      }
-    } else if (!isLoading && streamingMessageIdRef.current) {
-      // ストリーミングが終了した場合、isStreamingフラグをfalseに設定して参照をリセット
-      // useChatStoreをuseRootStoreに変更
-      useRootStore.getState().updateMessage(
-        streamingMessageIdRef.current,
-        { isStreaming: false }
-      );
-      streamingMessageIdRef.current = null;
-    }
-  }, [isLoading, originalMessages]);
+  // ストリーミングメッセージ管理
+  useStreamingMessages(isLoading, originalMessages as ExtendedMessage[])
 
   // 型変換用のヘルパー
   const messages = originalMessages as ExtendedMessage[];
@@ -186,231 +144,36 @@ Would you like to enter a long position at the current price of $60,500?`,
   
   // isLoadingをisSearchingに同期
   useEffect(() => {
-    setIsSearching(isLoading);
-  }, [isLoading]);
+    setIsSearching(isLoading)
+  }, [isLoading])
 
-  // Handle sample responses for specific keywords
-  const handleSubmitWithSamples = (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault()
+  // サンプルレスポンス処理を統合
+  const { handleSubmit } = useSampleResponses({
+    input,
+    messages,
+    setMessages,
+    setPendingEntry,
+    setIsSearching,
+    conversationId,
+    submit: originalHandleSubmit,
+  })
 
-    // 追加: 会話IDがある場合は常に通常のAI応答を使用
-    if (conversationId) {
-      setIsSearching(true)
-      originalHandleSubmit(e)
-      return
-    }
-
-    // Set searching state
-    setIsSearching(true)
-
-    // Check for specific keywords to trigger sample responses
-    if (input.toLowerCase().includes("entry point") || input.toLowerCase().includes("buy signal")) {
-      handleEntryPointQuery()
-      return
-    }
-
-    if (input.toLowerCase().includes("news") || input.toLowerCase().includes("latest")) {
-      handleNewsQuery()
-      return
-    }
-
-    // Default to normal AI response
-    originalHandleSubmit(e)
-  }
-
-  // 現在のユーザーIDを取得（実際のアプリケーションでは認証ストアなどから取得）
-  const getCurrentUserId = () => {
-    // 実際の実装では認証情報から取得する
-    return localStorage.getItem('userId') || 'current-user-id';
-  };
-
-  // AIメッセージから推定エントリー情報をセット (handleSubmitCallback内)
-  const handleSubmitCallback = useCallback((message: ExtendedMessage | Message) => {
-    // Check if the message suggests an entry
-    if (message.content.includes("enter") || message.content.includes("position")) {
-      // Extract entry details from AI message
-      const isBuy = !message.content.includes("sell") && !message.content.includes("short")
-      const priceMatch = message.content.match(/(\d+,?\d*)/)
-      const price = priceMatch
-        ? Number.parseFloat(priceMatch[0].replace(",", ""))
-        : ohlcData.length > 0 ? ohlcData[ohlcData.length - 1].close : 0
-
-      setPendingEntry({
-        id: Date.now().toString(),
-        userId: getCurrentUserId(), // 現在のユーザーIDを設定
-        side: isBuy ? "buy" : "sell",
-        symbol: "BTC/USD",
-        price,
-        time: new Date().toISOString(),
-        status: "open",
-      })
-    } else {
-      setPendingEntry(null)
-    }
-
-    // End searching state
-    setIsSearching(false)
-  }, [ohlcData, setPendingEntry, setIsSearching]);
-
-  // Handle entry point query
-  const handleEntryPointQuery = () => {
-    setMessages([
-      ...messages,
-      { id: Date.now().toString(), role: "user", content: input } as ExtendedMessage,
-      {
-        id: Date.now().toString() + "-response",
-        role: "assistant",
-        content: `Based on my analysis of the BTC/USD chart, I've identified a potential entry point.
-
-Technical Analysis:
-• Price is above the 50-day moving average, a bullish indicator
-• Recent high: $61,500, recent low: $59,500
-• Volume is average with no significant selling pressure
-
-Would you like to enter a long position at the current price of $60,500? Target: $62,000, Stop loss: $59,000.`,
-        isProposal: true,
-        proposalType: "buy",
-        price: 60500,
-      } as ExtendedMessage,
-    ])
-
-    // Set entry information
-    setPendingEntry({
-      id: Date.now().toString(),
-      userId: getCurrentUserId(), // 現在のユーザーIDを設定
-      side: "buy",
-      symbol: "BTC/USD",
-      price: 60500,
-      time: new Date().toISOString(),
-      status: "open",
-      takeProfit: 62000,
-      stopLoss: 59000,
+  // エントリー操作管理
+  const { handleAIProposalQuery, handleProceedWithEntry, handleCancelEntry } =
+    useEntryManager({
+      pendingEntry,
+      setPendingEntry,
+      executeEntry,
+      setActiveTab,
+      messages,
+      setMessages,
     })
-
-    // End searching state
-    setIsSearching(false)
-  }
-
-  // Handle news query
-  const handleNewsQuery = () => {
-    setMessages([
-      ...messages,
-      { id: Date.now().toString(), role: "user", content: input } as ExtendedMessage,
-      {
-        id: Date.now().toString() + "-response",
-        role: "assistant",
-        content: `Here are the latest Bitcoin news headlines:
-
-1. Bitcoin price surges 5% in the last 24 hours, reaching $60,500
-2. Major institutional investor announces $100M Bitcoin purchase
-3. New regulatory framework for cryptocurrencies proposed in the US
-4. Bitcoin mining difficulty increases by 3.4% after latest adjustment
-
-Would you like to enter a long position based on this positive news sentiment?`,
-        isProposal: true,
-        proposalType: "buy",
-        price: 60500,
-      } as ExtendedMessage,
-    ])
-
-    // Set entry information
-    setPendingEntry({
-      id: Date.now().toString(),
-      userId: getCurrentUserId(), // 現在のユーザーIDを設定
-      side: "buy",
-      symbol: "BTC/USD",
-      price: 60500,
-      time: new Date().toISOString(),
-      status: "open",
-    })
-
-    // End searching state
-    setIsSearching(false)
-  }
-
-  // Handle AI proposal query
-  const handleAIProposalQuery = () => {
-    // Get the latest proposal message
-    const latestProposal = useRootStore(selectLatestProposal)
-
-    // Use latest proposal details if available, otherwise use defaults
-    const proposalDetails = latestProposal
-      ? {
-          side: (latestProposal.proposalType === "buy" ? "buy" : "sell") as TradeSide,
-          price: latestProposal.price || 60500,
-          takeProfit: latestProposal.takeProfit,
-          stopLoss: latestProposal.stopLoss,
-        }
-      : {
-          side: "buy" as TradeSide,
-          price: 60500,
-          takeProfit: 62000,
-          stopLoss: 59000,
-        }
-
-    // Set entry information
-    setPendingEntry({
-      id: Date.now().toString(),
-      userId: getCurrentUserId(), // 現在のユーザーIDを設定
-      side: proposalDetails.side,
-      symbol: "BTC/USD",
-      price: proposalDetails.price,
-      time: new Date().toISOString(),
-      status: "open",
-      takeProfit: proposalDetails.takeProfit,
-      stopLoss: proposalDetails.stopLoss,
-    })
-
-    // Switch to the chart tab
-    setActiveTab("chart")
-
-    // End searching state
-    setIsSearching(false)
-  }
-
-  // Proceed with pending entry
-  const handleProceedWithEntry = () => {
-    if (pendingEntry) {
-      executeEntry()
-      setMessages([
-        ...messages,
-        {
-          id: Date.now().toString(),
-          role: "user",
-          content: "Proceed with the entry",
-        } as ExtendedMessage,
-        {
-          id: Date.now().toString() + "-response",
-          role: "assistant",
-          content: `Entry confirmed! I've opened a ${pendingEntry.side} position for you.`,
-        } as ExtendedMessage,
-      ])
-    }
-  }
-
-  // Cancel pending entry
-  const handleCancelEntry = () => {
-    setPendingEntry(null)
-    setMessages([
-      ...messages,
-      {
-        id: Date.now().toString(),
-        role: "user",
-        content: "Cancel trade",
-      } as ExtendedMessage,
-      {
-        id: Date.now().toString() + "-response",
-        role: "assistant",
-        content: "I've canceled the pending trade. Let me know if you'd like to explore other trading opportunities.",
-      } as ExtendedMessage,
-    ])
-  }
 
   return {
     messages,
     input,
     handleInputChange,
-    handleSubmit: handleSubmitWithSamples,
+    handleSubmit,
     isSearching,
     pendingEntry,
     handleProceedWithEntry,
@@ -418,4 +181,5 @@ Would you like to enter a long position based on this positive news sentiment?`,
     handleAIProposalQuery,
     error,
   }
-} 
+}
+

--- a/hooks/chat/useEntryManager.ts
+++ b/hooks/chat/useEntryManager.ts
@@ -1,0 +1,84 @@
+import type { ExtendedMessage } from '@/types/chat/base'
+import type { Entry, OpenEntry, TradeSide } from '@/types/entry'
+import { useRootStore, selectLatestProposal } from '@/store'
+import { getCurrentUserId } from './utils'
+
+interface UseEntryManagerProps {
+  pendingEntry: Entry | null
+  setPendingEntry: (entry: OpenEntry | null) => void
+  executeEntry: () => void
+  setActiveTab: (tab: string) => void
+  messages: ExtendedMessage[]
+  setMessages: (msgs: ExtendedMessage[]) => void
+}
+
+export function useEntryManager({
+  pendingEntry,
+  setPendingEntry,
+  executeEntry,
+  setActiveTab,
+  messages,
+  setMessages,
+}: UseEntryManagerProps) {
+  const handleAIProposalQuery = () => {
+    const latestProposal = useRootStore(selectLatestProposal)
+
+    const proposalDetails = latestProposal
+      ? {
+          side: (latestProposal.proposalType === 'buy' ? 'buy' : 'sell') as TradeSide,
+          price: latestProposal.price || 60500,
+          takeProfit: latestProposal.takeProfit,
+          stopLoss: latestProposal.stopLoss,
+        }
+      : {
+          side: 'buy' as TradeSide,
+          price: 60500,
+          takeProfit: 62000,
+          stopLoss: 59000,
+        }
+
+    setPendingEntry({
+      id: Date.now().toString(),
+      userId: getCurrentUserId(),
+      side: proposalDetails.side,
+      symbol: 'BTC/USD',
+      price: proposalDetails.price,
+      time: new Date().toISOString(),
+      status: 'open',
+      takeProfit: proposalDetails.takeProfit,
+      stopLoss: proposalDetails.stopLoss,
+    })
+
+    setActiveTab('chart')
+  }
+
+  const handleProceedWithEntry = () => {
+    if (pendingEntry) {
+      executeEntry()
+      setMessages([
+        ...messages,
+        { id: Date.now().toString(), role: 'user', content: 'Proceed with the entry' } as ExtendedMessage,
+        {
+          id: Date.now().toString() + '-response',
+          role: 'assistant',
+          content: `Entry confirmed! I've opened a ${pendingEntry.side} position for you.`,
+        } as ExtendedMessage,
+      ])
+    }
+  }
+
+  const handleCancelEntry = () => {
+    setPendingEntry(null)
+    setMessages([
+      ...messages,
+      { id: Date.now().toString(), role: 'user', content: 'Cancel trade' } as ExtendedMessage,
+      {
+        id: Date.now().toString() + '-response',
+        role: 'assistant',
+        content: "I've canceled the pending trade. Let me know if you'd like to explore other trading opportunities.",
+      } as ExtendedMessage,
+    ])
+  }
+
+  return { handleAIProposalQuery, handleProceedWithEntry, handleCancelEntry }
+}

--- a/hooks/chat/useSampleResponses.ts
+++ b/hooks/chat/useSampleResponses.ts
@@ -1,0 +1,120 @@
+import type { FormEvent } from 'react'
+import type { ExtendedMessage } from '@/types/chat/base'
+import type { OpenEntry } from '@/types/entry'
+import { getCurrentUserId } from './utils'
+
+interface UseSampleResponsesProps {
+  input: string
+  messages: ExtendedMessage[]
+  setMessages: (msgs: ExtendedMessage[]) => void
+  setPendingEntry: (entry: OpenEntry | null) => void
+  setIsSearching: (v: boolean) => void
+  conversationId?: string
+  submit: (e: FormEvent<HTMLFormElement>) => void
+}
+
+export function useSampleResponses({
+  input,
+  messages,
+  setMessages,
+  setPendingEntry,
+  setIsSearching,
+  conversationId,
+  submit,
+}: UseSampleResponsesProps) {
+  const handleEntryPointQuery = () => {
+    setMessages([
+      ...messages,
+      { id: Date.now().toString(), role: 'user', content: input } as ExtendedMessage,
+      {
+        id: Date.now().toString() + '-response',
+        role: 'assistant',
+        content: `Based on my analysis of the BTC/USD chart, I've identified a potential entry point.
+
+Technical Analysis:
+• Price is above the 50-day moving average, a bullish indicator
+• Recent high: $61,500, recent low: $59,500
+• Volume is average with no significant selling pressure
+
+Would you like to enter a long position at the current price of $60,500? Target: $62,000, Stop loss: $59,000.`,
+        isProposal: true,
+        proposalType: 'buy',
+        price: 60500,
+      } as ExtendedMessage,
+    ])
+
+    setPendingEntry({
+      id: Date.now().toString(),
+      userId: getCurrentUserId(),
+      side: 'buy',
+      symbol: 'BTC/USD',
+      price: 60500,
+      time: new Date().toISOString(),
+      status: 'open',
+      takeProfit: 62000,
+      stopLoss: 59000,
+    })
+
+    setIsSearching(false)
+  }
+
+  const handleNewsQuery = () => {
+    setMessages([
+      ...messages,
+      { id: Date.now().toString(), role: 'user', content: input } as ExtendedMessage,
+      {
+        id: Date.now().toString() + '-response',
+        role: 'assistant',
+        content: `Here are the latest Bitcoin news headlines:
+
+1. Bitcoin price surges 5% in the last 24 hours, reaching $60,500
+2. Major institutional investor announces $100M Bitcoin purchase
+3. New regulatory framework for cryptocurrencies proposed in the US
+4. Bitcoin mining difficulty increases by 3.4% after latest adjustment
+
+Would you like to enter a long position based on this positive news sentiment?`,
+        isProposal: true,
+        proposalType: 'buy',
+        price: 60500,
+      } as ExtendedMessage,
+    ])
+
+    setPendingEntry({
+      id: Date.now().toString(),
+      userId: getCurrentUserId(),
+      side: 'buy',
+      symbol: 'BTC/USD',
+      price: 60500,
+      time: new Date().toISOString(),
+      status: 'open',
+    })
+
+    setIsSearching(false)
+  }
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+
+    if (conversationId) {
+      setIsSearching(true)
+      submit(e)
+      return
+    }
+
+    setIsSearching(true)
+
+    if (input.toLowerCase().includes('entry point') || input.toLowerCase().includes('buy signal')) {
+      handleEntryPointQuery()
+      return
+    }
+
+    if (input.toLowerCase().includes('news') || input.toLowerCase().includes('latest')) {
+      handleNewsQuery()
+      return
+    }
+
+    submit(e)
+  }
+
+  return { handleSubmit, handleEntryPointQuery, handleNewsQuery }
+}

--- a/hooks/chat/useStreamingMessages.ts
+++ b/hooks/chat/useStreamingMessages.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from 'react'
+import { useRootStore } from '@/store'
+import type { ExtendedMessage } from '@/types/chat/base'
+
+/**
+ * Manage streaming assistant messages.
+ * Adds or updates a temporary message while the response is streaming.
+ */
+export function useStreamingMessages(
+  isLoading: boolean,
+  messages: ExtendedMessage[]
+) {
+  const streamingMessageIdRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (isLoading && messages.length > 0) {
+      const lastMessage = messages[messages.length - 1]
+      if (lastMessage.role === 'assistant') {
+        if (!streamingMessageIdRef.current) {
+          streamingMessageIdRef.current = `streaming-${Date.now()}`
+          const streamingMessage: ExtendedMessage = {
+            id: streamingMessageIdRef.current,
+            role: 'assistant',
+            content: lastMessage.content,
+            isStreaming: true,
+          }
+          useRootStore.getState().addMessage(streamingMessage)
+        } else {
+          useRootStore.getState().updateMessage(streamingMessageIdRef.current, {
+            content: lastMessage.content,
+            isStreaming: true,
+          })
+        }
+      }
+    } else if (!isLoading && streamingMessageIdRef.current) {
+      useRootStore.getState().updateMessage(streamingMessageIdRef.current, {
+        isStreaming: false,
+      })
+      streamingMessageIdRef.current = null
+    }
+  }, [isLoading, messages])
+}

--- a/hooks/chat/utils.ts
+++ b/hooks/chat/utils.ts
@@ -1,0 +1,6 @@
+/** Helper utilities for chat hooks */
+
+// Retrieve current user id from localStorage or fallback
+export const getCurrentUserId = () => {
+  return localStorage.getItem('userId') || 'current-user-id'
+}


### PR DESCRIPTION
## Summary
- extract streaming message handling
- extract sample response helpers
- extract entry management logic
- compose hooks in `useChatInteraction`
- test the new hooks

## Testing
- `npm test` *(fails: Cannot find module 'zustand' or its corresponding type declarations)*