### PR TITLE
Fix symbol store stubs and add tests

### DIFF
--- a/__tests__/store/symbol.test.ts
+++ b/__tests__/store/symbol.test.ts
@@ -1,0 +1,115 @@
+import { useRootStore } from '@/store/rootStore'
+import { symbolService } from '@/services/symbol'
+import type { SymbolInfo } from '@/types/symbol/common'
+
+jest.mock('@/services/symbol', () => ({
+  symbolService: {
+    fetchSymbols: jest.fn(),
+    saveLastUsedSymbol: jest.fn(),
+    saveLastUsedExchangeType: jest.fn(),
+    getLastUsedSymbol: jest.fn(),
+    getLastUsedExchangeType: jest.fn()
+  }
+}))
+
+const mockSymbols: SymbolInfo[] = [
+  {
+    id: '1',
+    symbol: 'BTCUSDT',
+    baseCoin: 'BTC',
+    quoteCoin: 'USDT',
+    minOrderSize: 0.001,
+    pricePrecision: 2,
+    quantityPrecision: 6,
+    status: 'TRADING',
+    exchangeType: 'spot',
+    favorite: false
+  },
+  {
+    id: '2',
+    symbol: 'ETHBTC',
+    baseCoin: 'ETH',
+    quoteCoin: 'BTC',
+    minOrderSize: 0.001,
+    pricePrecision: 2,
+    quantityPrecision: 6,
+    status: 'TRADING',
+    exchangeType: 'spot',
+    favorite: true
+  },
+  {
+    id: '3',
+    symbol: 'BNBUSDT',
+    baseCoin: 'BNB',
+    quoteCoin: 'USDT',
+    minOrderSize: 0.001,
+    pricePrecision: 2,
+    quantityPrecision: 6,
+    status: 'TRADING',
+    exchangeType: 'spot',
+    favorite: false
+  }
+]
+
+const setupStore = () => {
+  useRootStore.setState({
+    currentSymbol: '',
+    exchangeType: 'spot',
+    symbolsList: mockSymbols,
+    filteredSymbols: mockSymbols,
+    filterOptions: {
+      search: '',
+      quoteAsset: '',
+      showFavoritesOnly: false,
+      hideStablePairs: false
+    },
+    isLoading: false,
+    error: null,
+    changeHistory: []
+  })
+}
+
+describe('Symbol Slice Actions', () => {
+  beforeEach(() => {
+    setupStore()
+    jest.clearAllMocks()
+  })
+
+  it('setFilterOptions updates filter options and filtered symbols', () => {
+    useRootStore.getState().setFilterOptions({ quoteAsset: 'USDT' })
+
+    const state = useRootStore.getState()
+    expect(state.filterOptions.quoteAsset).toBe('USDT')
+    expect(state.filteredSymbols.every(s => s.quoteCoin === 'USDT')).toBe(true)
+  })
+
+  it('fetchSymbols populates symbols list and filtered list', async () => {
+    ;(symbolService.fetchSymbols as jest.Mock).mockResolvedValue(mockSymbols)
+
+    await useRootStore.getState().fetchSymbols('spot')
+
+    const state = useRootStore.getState()
+    expect(symbolService.fetchSymbols).toHaveBeenCalledWith('spot')
+    expect(state.symbolsList.length).toBe(mockSymbols.length)
+    expect(state.filteredSymbols.length).toBe(mockSymbols.length)
+    expect(state.isLoading).toBe(false)
+    expect(state.error).toBeNull()
+  })
+
+  it('clearHistory removes all history entries', () => {
+    useRootStore.getState().addToHistory({
+      symbol: 'BTCUSDT',
+      exchangeType: 'spot',
+      field: 'favorite',
+      oldValue: false,
+      newValue: true,
+      source: 'test'
+    })
+
+    expect(useRootStore.getState().changeHistory.length).toBe(1)
+
+    useRootStore.getState().clearHistory()
+
+    expect(useRootStore.getState().changeHistory.length).toBe(0)
+  })
+})

--- a/store/symbol/index.ts
+++ b/store/symbol/index.ts
@@ -71,76 +71,27 @@ export const createSymbolSlice = (
     setProductType: actions.setProductType,
     // 後方互換性のため旧メソッドも保持
     setExchangeType: actions.setExchangeType,
-    setSymbols: (symbols: SymbolInfo[]) => {
-      // 必要に応じて実装
-      console.log('setSymbols called', symbols);
-    },
-    addSymbol: (symbol: SymbolInfo) => {
-      // 必要に応じて実装
-      console.log('addSymbol called', symbol);
-    },
-    updateSymbol: (symbol: Partial<SymbolInfo> & { id: string }) => {
-      // 必要に応じて実装
-      console.log('updateSymbol called', symbol);
-    },
-    removeSymbol: (symbolId: string) => {
-      // 必要に応じて実装
-      console.log('removeSymbol called', symbolId);
-    },
-    setFilterOptions: (options: Partial<SymbolFilterOptions>) => {
-      // 必要に応じて実装
-      console.log('setFilterOptions called', options);
-    },
-    applyFilters: (options: SymbolFilterOptions) => {
-      // 必要に応じて実装
-      console.log('applyFilters called', options);
-    },
-    resetFilters: () => {
-      // 必要に応じて実装
-      console.log('resetFilters called');
-    },
-    fetchSymbols: (exchangeType?: ExchangeProductType) => {
-      // 必要に応じて実装
-      console.log('fetchSymbols called', exchangeType);
-      return Promise.resolve();
-    },
-    saveSymbol: (symbol: SymbolInfo) => {
-      // 必要に応じて実装
-      console.log('saveSymbol called', symbol);
-      return Promise.resolve();
-    },
-    deleteSymbol: (symbolId: string) => {
-      // 必要に応じて実装
-      console.log('deleteSymbol called', symbolId);
-      return Promise.resolve();
-    },
-    addToHistory: (entry: Omit<SymbolChangeHistoryEntry, 'id' | 'timestamp'>) => {
-      // 必要に応じて実装
-      console.log('addToHistory called', entry);
-    },
-    clearHistory: () => {
-      // 必要に応じて実装
-      console.log('clearHistory called');
-    },
+    setSymbols: actions.setSymbols,
+    addSymbol: actions.addSymbol,
+    updateSymbol: actions.updateSymbol,
+    removeSymbol: actions.removeSymbol,
+    setFilterOptions: actions.setFilterOptions,
+    applyFilters: actions.applyFilters,
+    resetFilters: actions.resetFilters,
+    fetchSymbols: actions.fetchSymbols,
+    saveSymbol: actions.saveSymbol,
+    deleteSymbol: actions.deleteSymbol,
+    addToHistory: actions.addToHistory,
+    clearHistory: actions.clearHistory,
     
     // お気に入りのトグル
-    toggleFavorite: (symbolId: string) => {
-      // 必要に応じて実装
-      console.log('toggleFavorite called', symbolId);
-    },
+    toggleFavorite: actions.toggleFavorite,
     
     // フィルターをクリア
-    clearFilters: () => {
-      // 必要に応じて実装
-      console.log('clearFilters called');
-    },
+    clearFilters: actions.clearFilters,
     
     // シンボル変更履歴を取得
-    getSymbolChangeHistory: () => {
-      // 必要に応じて実装
-      console.log('getSymbolChangeHistory called');
-      return [];
-    }
+    getSymbolChangeHistory: actions.getSymbolChangeHistory
   };
 };
 


### PR DESCRIPTION
## Summary
- wire up real implementations for symbol store actions
- add unit tests for symbol slice actions

## Testing
- `npm run typecheck:test` *(fails: Cannot find module 'zustand' or its corresponding type declarations)*