### PR TITLE
Fix candle subscription parameter

### DIFF
--- a/services/ccxws/client.ts
+++ b/services/ccxws/client.ts
@@ -414,7 +414,7 @@ export class CCXWSClient {
     };
     
     // トレードデータを購読
-    return this.subscribeTrades(symbol, handleTrade, exchangeType, exchange);
+    return this.subscribeTrades(symbol, handleTrade, exchangeProductType, exchange);
   }
 
   /**


### PR DESCRIPTION
## Summary
- ensure `exchangeProductType` is forwarded when subscribing to candle data

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails to find modules)*