### PR TITLE
Fix imports for bitget client

### DIFF
--- a/__tests__/data/order-book-service.test.ts
+++ b/__tests__/data/order-book-service.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { orderBookService } from '../../services/data/order-book-service';
-import { BitgetApiClient } from '../../services/api/bitget/client';
+import { BitgetApiClient } from '../../services/api/bitget/client.new';
 import { getSocketService } from '../../services/socket/service';
 import { OrderBookData } from '../../types/chart';
 
@@ -17,7 +17,7 @@ Object.defineProperty(global, 'window', {
 });
 
 // モック
-jest.mock('../../services/api/bitget/client');
+jest.mock('../../services/api/bitget/client.new');
 jest.mock('../../services/socket/service');
 
 describe('OrderBookService - ユニットテスト', () => {

--- a/__tests__/services/api/bitget/client.test.ts
+++ b/__tests__/services/api/bitget/client.test.ts
@@ -3,7 +3,7 @@
 
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { BitgetApiClient } from '../../../../services/api/bitget/client';
+import { BitgetApiClient } from '../../../../services/api/bitget/client.new';
 import { OHLCData } from '../../../../types/chart';
 
 // モック設定

--- a/__tests__/services/data/chart-data-service.test.ts
+++ b/__tests__/services/data/chart-data-service.test.ts
@@ -6,7 +6,7 @@
  * 更新: 2025-10-09: S-10.2フェーズ: ExchangeType型の一貫性を確保
  */
 
-import { BitgetApiClient } from '../../../services/api/bitget/client';
+import { BitgetApiClient } from '../../../services/api/bitget/client.new';
 import { chartDataService, getChartDataService, resetChartDataServiceForTesting } from '../../../services/data/chart-data-service';
 import { cacheService } from '../../../services/cache/service';
 import { getSocketService } from '../../../services/socket/index';
@@ -27,7 +27,7 @@ const PRODUCT_TYPES = {
 };
 
 // モック
-jest.mock('../../../services/api/bitget/client');
+jest.mock('../../../services/api/bitget/client.new');
 jest.mock('../../../services/cache/service');
 jest.mock('../../../services/socket/index');
 jest.mock('../../../utils/logger');

--- a/__tests__/services/socket/bitget-integration.test.ts
+++ b/__tests__/services/socket/bitget-integration.test.ts
@@ -6,12 +6,12 @@
  */
 
 import { BitgetIntegration } from '../../../services/socket/bitget-integration';
-import { BitgetApiClient } from '../../../services/api/bitget/client';
+import { BitgetApiClient } from '../../../services/api/bitget/client.new';
 import { ProductType } from '@/types/api';
 import { logger } from '../../../utils/logger';
 
 // BitgetApiClientのモック
-jest.mock('../../../services/api/bitget/client', () => {
+jest.mock('../../../services/api/bitget/client.new', () => {
   return {
     BitgetApiClient: jest.fn().mockImplementation(() => ({
       disconnectWebSocket: jest.fn(),

--- a/__tests__/services/socket/socket-service.test.ts
+++ b/__tests__/services/socket/socket-service.test.ts
@@ -11,7 +11,7 @@ import { IWebSocketClient, ISubscriptionManager, IBitgetIntegration } from '../.
 import { OrderBookData } from '../../../types/market';
 import { OHLCData } from '../../../types/chart';
 import { ProductType } from '@/types/api';
-import { BitgetApiClient } from '../../../services/api/bitget/client';
+import { BitgetApiClient } from '../../../services/api/bitget/client.new';
 import { logger } from '../../../utils/logger';
 
 // モック

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,6 +43,7 @@
   ],
   "exclude": [
     "node_modules",
-    ".next"
+    ".next",
+    "archive"
   ]
 }


### PR DESCRIPTION
## Summary
- update tests to import `services/api/bitget/client.new`
- exclude `archive` directory from tsconfig typecheck

## Testing
- `pnpm typecheck` *(fails: Cannot find module 'react', etc.)*