### PR TITLE
Fix environment import path in API services

### DIFF
--- a/services/api/common/index.ts
+++ b/services/api/common/index.ts
@@ -1,5 +1,5 @@
 // services/api/common/index.ts
 // 作成: 共通機能のエクスポート
 
-export * from './environment';
+export * from '@/config/environment';
 export * from './request';

--- a/services/api/common/request.ts
+++ b/services/api/common/request.ts
@@ -11,7 +11,7 @@ import {
   ApiRequestOptions,
   CancellableRequest
 } from '@/types/api';
-import { IS_DEV, IS_BROWSER, getApiConfig } from './environment';
+import { IS_DEV, IS_BROWSER, getApiConfig } from '@/config/environment';
 
 /**
  * 共通APIリクエスト関数


### PR DESCRIPTION
## Summary
- update environment export path in the common index
- use the shared config environment module in the request utility

## Testing
- `npx tsc -p tmp.tsconfig.json --noEmit` *(fails: Cannot find name 'process' and missing modules)*
- `npm test` *(fails to run due to missing module type definitions)*