### PR TITLE
Use product type for kline subscriptions

### DIFF
--- a/docs/websocket-shared-data.md
+++ b/docs/websocket-shared-data.md
@@ -260,7 +260,7 @@ fetchChartData(
 subscribeOrderBookRealtime(
   symbol: string,
   callback: (data: OrderBookData) => void,
-  exchangeType: ExchangeType = 'spot'
+  productType: ProductType = 'spot'
 ): () => void
 
 // ローソク足データをリアルタイム購読
@@ -268,7 +268,7 @@ subscribeKlineRealtime(
   symbol: string,
   timeFrame: Timeframe,
   callback: (data: OHLCData) => void,
-  exchangeType: ExchangeType = 'spot'
+  productType: ProductType = 'spot'
 ): () => void
 ```
 

--- a/services/data/chart-data-service.ts
+++ b/services/data/chart-data-service.ts
@@ -10,7 +10,8 @@ import { EventEmitter } from 'events';
 import { BitgetApiClient } from '../api/bitget/client.new';
 import { IChartDataService } from './interfaces';
 import { OHLCData, Timeframe } from '../../types/chart';
-import { ExchangeType } from '@/types/api';
+import { ExchangeType, ProductType } from '@/types/api';
+import { useRootStore } from '../../store/rootStore';
 import { logger } from '../../utils/logger';
 import { normalizeSymbol } from '../../utils/formatters';
 import { getSocketService } from '../socket/index';
@@ -126,11 +127,13 @@ class ChartDataService extends EventEmitter implements IChartDataService {
     symbol: string,
     timeFrame: Timeframe,
     callback: (data: OHLCData) => void,
-    exchangeType: ExchangeType = 'bitget'
+    productType?: ProductType
   ): () => void {
     try {
       const normalizedSymbol = normalizeSymbol(symbol);
-      const subscriptionKey = `kline_${normalizedSymbol}_${timeFrame}_${exchangeType}`;
+      const storeType = useRootStore.getState().exchangeProductType;
+      const finalType = productType || storeType;
+      const subscriptionKey = `kline_${normalizedSymbol}_${timeFrame}_${finalType}`;
       
       // 既存の購読があれば解除
       if (this.subscriptions.has(subscriptionKey)) {
@@ -146,9 +149,9 @@ class ChartDataService extends EventEmitter implements IChartDataService {
           action: 'subscribeKlineRealtime',
           symbol: normalizedSymbol,
           timeFrame,
-          exchangeType
+          exchangeType: finalType
         });
-        
+
         const socketService = getSocketService();
         const unsubscribe = socketService.subscribeKline(
           normalizedSymbol,
@@ -164,7 +167,7 @@ class ChartDataService extends EventEmitter implements IChartDataService {
               data
             });
           },
-          exchangeType
+          finalType
         );
         
         // 購読を保存

--- a/services/data/dataFetchService.ts
+++ b/services/data/dataFetchService.ts
@@ -17,7 +17,9 @@ import { EventEmitter } from 'events';
 import { BitgetApiClient } from '../api/bitget/client.new';
 import { IDataFetchService } from './dataFetchTypes';
 import { OHLCData, Timeframe } from '../../types/chart';
-import { ExchangeType } from '@/types/api';
+import { ExchangeType, ProductType } from '@/types/api';
+import { useRootStore } from '../../store/rootStore';
+import { toExchangeType } from '@/utils/exchangeTypeUtils';
 import { logger } from '../../utils/logger';
 import { normalizeSymbol } from '../../utils/formatters';
 import { getSocketService } from '../socket/service';
@@ -199,10 +201,13 @@ class DataFetchService extends EventEmitter implements IDataFetchService {
     symbol: string,
     timeFrame: Timeframe,
     callback: (data: OHLCData) => void,
-    exchangeType: ExchangeType = 'bitget'
+    productType?: ProductType
   ): () => void {
     // シンボルを正規化
     const normalizedSymbol = normalizeSymbol(symbol);
+    const storeType = useRootStore.getState().exchangeProductType;
+    const finalType = productType || storeType;
+    const exchangeType = toExchangeType(finalType);
     
     // ブラウザ環境ではポーリングで対応
     if (isBrowser) {
@@ -211,7 +216,7 @@ class DataFetchService extends EventEmitter implements IDataFetchService {
         action: 'subscribeKlineRealtime',
         symbol: normalizedSymbol,
         timeFrame,
-        exchangeType,
+        exchangeType: finalType,
         client: 'polling'
       });
       
@@ -243,7 +248,7 @@ class DataFetchService extends EventEmitter implements IDataFetchService {
             action: 'subscribeKlineRealtime',
             symbol: normalizedSymbol,
             timeFrame,
-            exchangeType,
+            exchangeType: finalType,
             error
           });
         }
@@ -265,7 +270,7 @@ class DataFetchService extends EventEmitter implements IDataFetchService {
         action: 'subscribeKlineRealtime',
         symbol: normalizedSymbol,
         timeFrame,
-        exchangeType
+        exchangeType: finalType
       });
       return () => {};
     }
@@ -276,7 +281,7 @@ class DataFetchService extends EventEmitter implements IDataFetchService {
       timeFrame,
       (data: OHLCData) => {
         // データをキャッシュに保存（既存のキャッシュがあれば更新）
-        const requestKey = `chart-${normalizedSymbol}-${timeFrame}-${exchangeType}`;
+        const requestKey = `chart-${normalizedSymbol}-${timeFrame}-${finalType}`;
         const cachedData = cacheService.get<OHLCData[]>(requestKey);
         
         if (cachedData && Array.isArray(cachedData)) {
@@ -301,7 +306,7 @@ class DataFetchService extends EventEmitter implements IDataFetchService {
         // コールバック関数を呼び出し
         callback(data);
       },
-      exchangeType
+      finalType
     );
     
     logger.info(`WebSocketでローソク足データのリアルタイム購読を開始: ${normalizedSymbol} ${timeFrame}`, {
@@ -309,7 +314,7 @@ class DataFetchService extends EventEmitter implements IDataFetchService {
       action: 'subscribeKlineRealtime',
       symbol: normalizedSymbol,
       timeFrame,
-      exchangeType,
+      exchangeType: finalType,
       client: 'socket-service'
     });
     

--- a/services/data/dataFetchTypes.ts
+++ b/services/data/dataFetchTypes.ts
@@ -5,7 +5,7 @@
  * 作成: データフェッチサービスのインターフェースと型定義
  */
 
-import { ExchangeType } from '@/types/api';
+import { ExchangeType, ProductType } from '@/types/api';
 import { OHLCData, Timeframe } from '../../types/chart';
 
 export interface IDataFetchService {
@@ -15,7 +15,7 @@ export interface IDataFetchService {
    * チャートデータ取得
    * @param symbol シンボル
    * @param timeFrame タイムフレーム
-   * @param exchangeType 取引タイプ
+   * @param productType 取引タイプ
    * @param signal AbortSignal
    * @param useCache キャッシュを使用するかどうか
    * @returns チャートデータの配列
@@ -42,7 +42,7 @@ export interface IDataFetchService {
     symbol: string,
     timeFrame: Timeframe,
     callback: (data: OHLCData) => void,
-    exchangeType?: ExchangeType
+    productType?: ProductType
   ): () => void;
   
   /**

--- a/services/data/interfaces.ts
+++ b/services/data/interfaces.ts
@@ -6,7 +6,7 @@
  * 各サービスのインターフェースを明確に定義
  */
 
-import { ExchangeType } from '@/types/api';
+import { ExchangeType, ProductType } from '@/types/api';
 import { OHLCData, Timeframe, OrderBookData } from '../../types/chart';
 
 /**
@@ -80,7 +80,7 @@ export interface IChartDataService {
     symbol: string,
     timeFrame: Timeframe,
     callback: (data: OHLCData) => void,
-    exchangeType?: ExchangeType
+    productType?: ProductType
   ): () => void;
   
   /**


### PR DESCRIPTION
## Summary
- pass `ProductType` to `subscribeKlineRealtime`
- read default product type from `exchangeProductType`
- document new parameter

## Testing
- `npm test` *(fails: Cannot find module 'zustand')*