### PR TITLE
Use ProductType in symbol selector logic

### DIFF
--- a/__tests__/validations/symbol.test.ts
+++ b/__tests__/validations/symbol.test.ts
@@ -103,8 +103,8 @@ describe('Symbol Validations', () => {
       const validProps = {
         onSelect: (symbol: string) => {},
         currentSymbol: 'BTCUSDT',
-        defaultExchangeType: 'spot' as ProductType,
-        onExchangeTypeChange: (type: ProductType) => {}
+        defaultProductType: 'spot' as ProductType,
+        onProductTypeChange: (type: ProductType) => {}
       };
 
       const result = symbolSelectorPropsSchema.safeParse(validProps);
@@ -115,7 +115,7 @@ describe('Symbol Validations', () => {
       const invalidProps = {
         // onSelectが欠けている
         currentSymbol: 'BTCUSDT',
-        defaultExchangeType: 'spot' as ProductType
+        defaultProductType: 'spot' as ProductType
       };
 
       const result = symbolSelectorPropsSchema.safeParse(invalidProps);
@@ -126,7 +126,7 @@ describe('Symbol Validations', () => {
       const validProps = {
         onSelect: (symbol: string) => {},
         currentSymbol: 'BTCUSDT',
-        defaultExchangeType: 'spot' as ProductType
+        defaultProductType: 'spot' as ProductType
       };
 
       const result = validateSymbolSelectorProps(validProps);

--- a/components/chart/SymbolSelectorModal.tsx
+++ b/components/chart/SymbolSelectorModal.tsx
@@ -6,7 +6,7 @@
 // 更新: 2025-10-09 - S-9.2フェーズ: ExchangeType型の参照を統一し型変換を追加
 
 import { useState, useEffect } from 'react';
-import { type ExchangeType, type ExchangeProductType } from '@/types/constants/enums';
+import { type ProductType } from '@/types/constants/enums';
 import {
   Dialog,
   DialogContent,
@@ -17,21 +17,21 @@ import {
 import { Button } from '@/components/ui/button';
 import SymbolSelector from '@/components/SymbolSelector';
 import { CandlestickChart } from 'lucide-react';
-import { safeExchangeType } from '@/utils/exchangeTypeUtils';
+import { safeProductType } from '@/utils/exchangeTypeUtils';
 
 interface SymbolSelectorModalProps {
   currentSymbol: string;
   onSymbolSelect: (symbol: string) => void;
-  exchangeType?: ExchangeType | ExchangeProductType;
-  onExchangeTypeChange?: (exchangeType: ExchangeType | ExchangeProductType) => void;
+  productType?: ProductType;
+  onProductTypeChange?: (productType: ProductType) => void;
   trigger?: React.ReactNode;
 }
 
 export default function SymbolSelectorModal({
   currentSymbol,
   onSymbolSelect,
-  exchangeType = 'bitget', // デフォルト値を'spot'から'bitget'に変更
-  onExchangeTypeChange,
+  productType = 'spot',
+  onProductTypeChange,
   trigger
 }: SymbolSelectorModalProps) {
   const [open, setOpen] = useState(false);
@@ -48,11 +48,11 @@ export default function SymbolSelectorModal({
     setOpen(false);
   };
   
-  // 型安全な交換タイプ変更ハンドラ
-  const handleExchangeTypeChange = onExchangeTypeChange 
+  // 型安全な取引タイプ変更ハンドラ
+  const handleProductTypeChange = onProductTypeChange
     ? (newType: any) => {
         // 型変換して親コンポーネントに渡す
-        onExchangeTypeChange(safeExchangeType(newType));
+        onProductTypeChange(safeProductType(newType));
       }
     : undefined;
 
@@ -74,8 +74,8 @@ export default function SymbolSelectorModal({
           <SymbolSelector
             onSelect={handleSymbolSelect}
             currentSymbol={currentSymbol}
-            defaultExchangeType={safeExchangeType(exchangeType)}
-            onExchangeTypeChange={handleExchangeTypeChange}
+            defaultProductType={safeProductType(productType)}
+            onProductTypeChange={handleProductTypeChange}
           />
         </div>
       </DialogContent>

--- a/components/chart/toolbar/index.tsx
+++ b/components/chart/toolbar/index.tsx
@@ -89,9 +89,9 @@ const ChartToolbar = memo(function ChartToolbar({
       <div className="flex justify-between items-center py-2 px-3 border-b border-border-light bg-background-secondary">
         <SymbolPriceBar
           currentSymbol={symbolStore.currentSymbol}
-          exchangeType={symbolStore.exchangeType as ExchangeProductType}
+          productType={symbolStore.exchangeType as ExchangeProductType}
           onSymbolChange={symbolStore.handleSymbolChange}
-          onExchangeTypeChange={symbolStore.setProductType}
+          onProductTypeChange={(type) => symbolStore.setProductType(type as ExchangeProductType)}
           currentPrice={currentPrice}
           priceChangePercent={priceChangePercent}
           mounted={mounted}

--- a/components/chart/toolbar/ui/SymbolPriceBar.tsx
+++ b/components/chart/toolbar/ui/SymbolPriceBar.tsx
@@ -15,17 +15,17 @@ import { Badge } from '@/components/ui/badge';
 import { CandlestickChart } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import SymbolSelectorModal from '../../SymbolSelectorModal';
-import { ExchangeType, ExchangeProductType } from '@/types/constants/enums';
+import { ProductType } from '@/types/constants/enums';
 import { SymbolSelector } from '@/components/symbol/Selector';
 import { ExchangeSelector } from '@/components/symbol/ExchangeSelector';
-import { safeExchangeType } from '@/utils/exchangeTypeUtils';
+import { safeProductType } from '@/utils/exchangeTypeUtils';
 
 interface SymbolPriceBarProps {
   // シンボル関連
   currentSymbol: string;
-  exchangeType: ExchangeType | ExchangeProductType;
+  productType: ProductType;
   onSymbolChange: (symbol: string) => void;
-  onExchangeTypeChange: (type: ExchangeType | ExchangeProductType) => void;
+  onProductTypeChange: (type: ProductType) => void;
   
   // 価格関連
   currentPrice: number | null;
@@ -39,9 +39,9 @@ interface SymbolPriceBarProps {
 const SymbolPriceBar = memo(function SymbolPriceBar({
   // シンボル関連props
   currentSymbol,
-  exchangeType,
+  productType,
   onSymbolChange,
-  onExchangeTypeChange,
+  onProductTypeChange,
   
   // 価格関連props
   currentPrice,
@@ -53,9 +53,9 @@ const SymbolPriceBar = memo(function SymbolPriceBar({
       {/* 銘柄選択モーダル */}
       <SymbolSelectorModal
         currentSymbol={currentSymbol}
-        exchangeType={safeExchangeType(exchangeType)}
+        productType={safeProductType(productType)}
         onSymbolSelect={onSymbolChange}
-        onExchangeTypeChange={onExchangeTypeChange}
+        onProductTypeChange={onProductTypeChange}
         trigger={
           <Button variant="outline" size="sm" className="gap-1">
             <CandlestickChart className="h-4 w-4" />

--- a/components/symbol/Selector/SymbolSelector.tsx
+++ b/components/symbol/Selector/SymbolSelector.tsx
@@ -12,7 +12,7 @@
  * - 2025-06-05: T-7.7.1フェーズ - 型インポートパスを修正
  * - 2025-06-05: T-7.7.2フェーズ - 内部関数の名前衝突を解消
  * - 2025-06-05: T-7.7.3フェーズ - プロパティ名を統一（quoteCoin→quoteCoin、favorite→favorite）
- * - 2025-10-09: S-9.2フェーズ - ExchangeType型の参照を統一
+ * - 2025-10-09: S-9.2フェーズ - ProductType型の参照を統一
  * - 2025-10-09: S-9.2フェーズ - FilterOptions型のインポートパス修正
  */
 
@@ -33,7 +33,7 @@ import { logger } from '@/utils/common';
 
 import { AdvancedSelectorView } from './ui/AdvancedSelectorView';
 // アイコンは子コンポーネントで使用されるため、ここでのインポートは不要
-import { type ExchangeType } from '@/types/constants/enums';
+import { type ProductType } from '@/types/constants/enums';
 import { validateSymbolSelectorProps } from '@/lib/validations/symbol';
 import type { SymbolSelectorPropsSchema } from '@/lib/validations/symbol';
 import {
@@ -121,21 +121,21 @@ export const SymbolSelector: React.FC<SymbolSelectorProps> = ({
  * 
  * @param onSelect 銘柄選択時のコールバック
  * @param currentSymbol 現在選択されている銘柄
- * @param defaultExchangeType デフォルトの取引タイプ
- * @param onExchangeTypeChange 取引タイプ変更時のコールバック
- */
+ * @param defaultProductType デフォルトの取引タイプ
+ * @param onProductTypeChange 取引タイプ変更時のコールバック
+*/
 export default function AdvancedSymbolSelector({
   onSelect,
   currentSymbol = 'BTCUSDT',
-  defaultExchangeType = 'bitget',
-  onExchangeTypeChange,
+  defaultProductType = 'spot',
+  onProductTypeChange,
 }: SymbolSelectorPropsSchema) {
   // プロパティのバリデーション
   const propsValidation = validateSymbolSelectorProps({
     onSelect,
     currentSymbol,
-    defaultExchangeType,
-    onExchangeTypeChange
+    defaultProductType,
+    onProductTypeChange
   });
   
   if (!propsValidation.success) {
@@ -151,8 +151,8 @@ export default function AdvancedSymbolSelector({
     actions: { toggleFavorite, retryFetch },
     productType: { current: productType, handleChange: handleProductTypeChange }
   } = useSymbolSelectorLogic({
-    defaultExchangeType,
-    onExchangeTypeChange
+    defaultProductType,
+    onProductTypeChange
   });
   
   // フィルター状態を管理するフックを使用

--- a/hooks/symbol/selector/useSymbolSelectorLogic.ts
+++ b/hooks/symbol/selector/useSymbolSelectorLogic.ts
@@ -11,19 +11,19 @@ import {
   selectIsLoadingSymbols,
   selectSymbolError
 } from '@/store/barrel';
-import type { ExchangeType } from '@/types/constants/enums';
+import type { ProductType } from '@/types/constants/enums';
 
 interface UseSymbolSelectorLogicOptions {
-  defaultExchangeType?: ExchangeType;
-  onExchangeTypeChange?: (type: ExchangeType) => void;
+  defaultProductType?: ProductType;
+  onProductTypeChange?: (type: ProductType) => void;
 }
 
 /**
  * セレクターで使用するストアのロジックを管理するフック
  */
 export const useSymbolSelectorLogic = ({
-  defaultExchangeType,
-  onExchangeTypeChange
+  defaultProductType,
+  onProductTypeChange
 }: UseSymbolSelectorLogicOptions = {}) => {
   // RootStoreから状態を取得
   const symbols = useRootStore(selectFilteredSymbols);
@@ -39,13 +39,13 @@ export const useSymbolSelectorLogic = ({
 
   // 取引タイプの変更ハンドラー
   const handleProductTypeChange = useCallback(
-    (type: ExchangeType) => {
+    (type: ProductType) => {
       setProductType(type);
-      if (onExchangeTypeChange) {
-        onExchangeTypeChange(type);
+      if (onProductTypeChange) {
+        onProductTypeChange(type);
       }
     },
-    [setProductType, onExchangeTypeChange]
+    [setProductType, onProductTypeChange]
   );
 
   // 再試行ハンドラー
@@ -55,10 +55,10 @@ export const useSymbolSelectorLogic = ({
 
   // デフォルトの取引タイプが指定されていれば設定
   useEffect(() => {
-    if (defaultExchangeType && defaultExchangeType !== currentProductType) {
-      setProductType(defaultExchangeType);
+    if (defaultProductType && defaultProductType !== currentProductType) {
+      setProductType(defaultProductType);
     }
-  }, [defaultExchangeType, currentProductType, setProductType]);
+  }, [defaultProductType, currentProductType, setProductType]);
 
   return {
     symbols: { filteredSymbols: symbols, isLoading, error },

--- a/lib/validations/symbol.ts
+++ b/lib/validations/symbol.ts
@@ -3,8 +3,8 @@
 // 更新: 2025-10-09 - S-9.2フェーズ: ExchangeType型の参照を統一
 
 import { z } from "zod"
-import { type ExchangeType, type ExchangeProductType } from "@/types/constants/enums"
-import { safeExchangeType, safeProductType } from "@/utils/exchangeTypeUtils";
+import { type ProductType } from '@/types/constants/enums'
+
 
 // シンボル情報のバリデーションスキーマ
 export const symbolInfoSchema = z.object({
@@ -32,9 +32,9 @@ export const symbolSelectorPropsSchema = z.object({
     .args(z.string())
     .returns(z.void()),
   currentSymbol: z.string().default("BTCUSDT"),
-  defaultExchangeType: z.enum(["bitget", "binance", "bybit", "demo"]).default("bitget"),
-  onExchangeTypeChange: z.function()
-    .args(z.enum(["bitget", "binance", "bybit", "demo"]))
+  defaultProductType: z.enum(["spot", "futures"]).default("spot"),
+  onProductTypeChange: z.function()
+    .args(z.enum(["spot", "futures"]))
     .returns(z.void())
     .optional()
 })

--- a/types/validations/symbol.ts
+++ b/types/validations/symbol.ts
@@ -2,7 +2,7 @@
 // 作成: シンボルセレクター関連のZodバリデーションスキーマ
 
 import { z } from "zod"
-import { ExchangeType } from "@/types/constants/enums"
+import { ProductType } from "@/types/constants/enums"
 
 // シンボル情報のバリデーションスキーマ
 export const symbolInfoSchema = z.object({
@@ -30,8 +30,8 @@ export const symbolSelectorPropsSchema = z.object({
     .args(z.string())
     .returns(z.void()),
   currentSymbol: z.string().default("BTCUSDT"),
-  defaultExchangeType: z.enum(["spot", "futures"]).default("spot"),
-  onExchangeTypeChange: z.function()
+  defaultProductType: z.enum(["spot", "futures"]).default("spot"),
+  onProductTypeChange: z.function()
     .args(z.enum(["spot", "futures"]))
     .returns(z.void())
     .optional()


### PR DESCRIPTION
## Summary
- switch useSymbolSelectorLogic to accept ProductType
- forward ProductType through SymbolSelector and related components
- update validation schemas and tests

## Testing
- `npm test` *(fails: Cannot find module 'zustand')*
- `npm run lint` *(fails: next not found)*