### PR TITLE
Update filter state API

### DIFF
--- a/__tests__/hooks/symbol/useFilterState.test.ts
+++ b/__tests__/hooks/symbol/useFilterState.test.ts
@@ -29,9 +29,9 @@ describe('useFilterState', () => {
       setFilterOptions: jest.fn(),
       clearFilters: jest.fn(),
       filterOptions: {
-        searchTerm: '',
-        quoteCoin: '',
-        favoritesOnly: false,
+        search: '',
+        quoteAsset: '',
+        showFavoritesOnly: false,
       },
     });
     
@@ -49,9 +49,9 @@ describe('useFilterState', () => {
     
     // フックが正しく初期化されていることを確認
     expect(result.current.filterOptions).toEqual({
-      searchTerm: '',
-      quoteCoin: '',
-      favoritesOnly: false,
+      search: '',
+      quoteAsset: '',
+      showFavoritesOnly: false,
     });
     
     // コモン基軸通貨が正しいことを確認
@@ -64,9 +64,9 @@ describe('useFilterState', () => {
       setFilterOptions: mockSetFilterOptions,
       clearFilters: jest.fn(),
       filterOptions: {
-        searchTerm: '',
-        quoteCoin: '',
-        favoritesOnly: false,
+        search: '',
+        quoteAsset: '',
+        showFavoritesOnly: false,
       },
     });
     
@@ -78,7 +78,7 @@ describe('useFilterState', () => {
     });
     
     // setFilterOptionsが正しい引数で呼ばれていることを確認
-    expect(mockSetFilterOptions).toHaveBeenCalledWith({ searchTerm: 'BTC' });
+    expect(mockSetFilterOptions).toHaveBeenCalledWith({ search: 'BTC' });
   });
   
   test('基軸通貨フィルターが正しく動作する', () => {
@@ -87,9 +87,9 @@ describe('useFilterState', () => {
       setFilterOptions: mockSetFilterOptions,
       clearFilters: jest.fn(),
       filterOptions: {
-        searchTerm: '',
-        quoteCoin: '',
-        favoritesOnly: false,
+        search: '',
+        quoteAsset: '',
+        showFavoritesOnly: false,
       },
     });
     
@@ -101,7 +101,7 @@ describe('useFilterState', () => {
     });
     
     // setFilterOptionsが正しい引数で呼ばれていることを確認
-    expect(mockSetFilterOptions).toHaveBeenCalledWith({ quoteCoin: 'USDT' });
+    expect(mockSetFilterOptions).toHaveBeenCalledWith({ quoteAsset: 'USDT' });
   });
   
   test('お気に入りトグルが正しく動作する', () => {
@@ -110,9 +110,9 @@ describe('useFilterState', () => {
       setFilterOptions: mockSetFilterOptions,
       clearFilters: jest.fn(),
       filterOptions: {
-        searchTerm: '',
-        quoteCoin: '',
-        favoritesOnly: false,
+        search: '',
+        quoteAsset: '',
+        showFavoritesOnly: false,
       },
     });
     
@@ -124,7 +124,7 @@ describe('useFilterState', () => {
     });
     
     // setFilterOptionsが正しい引数で呼ばれていることを確認
-    expect(mockSetFilterOptions).toHaveBeenCalledWith({ favoritesOnly: true });
+    expect(mockSetFilterOptions).toHaveBeenCalledWith({ showFavoritesOnly: true });
   });
   
   test('フィルターリセットが正しく動作する', () => {
@@ -133,9 +133,9 @@ describe('useFilterState', () => {
       setFilterOptions: jest.fn(),
       clearFilters: mockClearFilters,
       filterOptions: {
-        searchTerm: 'BTC',
-        quoteCoin: 'USDT',
-        favoritesOnly: true,
+        search: 'BTC',
+        quoteAsset: 'USDT',
+        showFavoritesOnly: true,
       },
     });
     

--- a/__tests__/hooks/symbol/usePopularSymbols.test.ts
+++ b/__tests__/hooks/symbol/usePopularSymbols.test.ts
@@ -73,9 +73,9 @@ const mockSymbols: SymbolInfo[] = [
 
 // デフォルトフィルターオプション
 const defaultFilters: FilterOptions = {
-  searchTerm: '',
-  quoteCoin: '',
-  favoritesOnly: false,
+  search: '',
+  quoteAsset: '',
+  showFavoritesOnly: false,
 };
 
 describe('usePopularSymbols', () => {
@@ -96,13 +96,13 @@ describe('usePopularSymbols', () => {
     );
   });
   
-  test('searchTermが適用されている場合、空配列を返す', () => {
+  test('searchが適用されている場合、空配列を返す', () => {
     const { result } = renderHook(() => 
       usePopularSymbols({
         symbols: mockSymbols,
         filterOptions: {
           ...defaultFilters,
-          searchTerm: 'BTC',
+          search: 'BTC',
         },
       })
     );
@@ -111,13 +111,13 @@ describe('usePopularSymbols', () => {
     expect(result.current).toHaveLength(0);
   });
   
-  test('quoteCoinが適用されている場合、空配列を返す', () => {
+  test('quoteAssetが適用されている場合、空配列を返す', () => {
     const { result } = renderHook(() => 
       usePopularSymbols({
         symbols: mockSymbols,
         filterOptions: {
           ...defaultFilters,
-          quoteCoin: 'USDT',
+          quoteAsset: 'USDT',
         },
       })
     );
@@ -126,13 +126,13 @@ describe('usePopularSymbols', () => {
     expect(result.current).toHaveLength(0);
   });
   
-  test('favoritesOnlyが適用されている場合、空配列を返す', () => {
+  test('showFavoritesOnlyが適用されている場合、空配列を返す', () => {
     const { result } = renderHook(() => 
       usePopularSymbols({
         symbols: mockSymbols,
         filterOptions: {
           ...defaultFilters,
-          favoritesOnly: true,
+          showFavoritesOnly: true,
         },
       })
     );

--- a/__tests__/validations/symbol.test.ts
+++ b/__tests__/validations/symbol.test.ts
@@ -64,9 +64,9 @@ describe('Symbol Validations', () => {
   describe('filterOptionsSchema', () => {
     it('有効なフィルターオプションを検証できる', () => {
       const validOptions = {
-        searchTerm: 'BTC',
-        quoteCoin: 'USDT',
-        favoritesOnly: true
+        search: 'BTC',
+        quoteAsset: 'USDT',
+        showFavoritesOnly: true
       };
 
       const result = filterOptionsSchema.safeParse(validOptions);
@@ -78,19 +78,19 @@ describe('Symbol Validations', () => {
 
       const result = filterOptionsSchema.safeParse(emptyOptions);
       expect(result.success).toBe(true);
-      
+
       if (result.success) {
-        expect(result.data.searchTerm).toBe('');
-        expect(result.data.quoteCoin).toBe('');
-        expect(result.data.favoritesOnly).toBe(false);
+        expect(result.data.search).toBe('');
+        expect(result.data.quoteAsset).toBe('');
+        expect(result.data.showFavoritesOnly).toBe(false);
       }
     });
 
     it('validateFilterOptions関数が正しく動作する', () => {
       const validOptions = {
-        searchTerm: 'BTC',
-        quoteCoin: 'USDT',
-        favoritesOnly: true
+        search: 'BTC',
+        quoteAsset: 'USDT',
+        showFavoritesOnly: true
       };
 
       const result = validateFilterOptions(validOptions);

--- a/lib/validations/symbol.ts
+++ b/lib/validations/symbol.ts
@@ -21,9 +21,9 @@ export const symbolInfoSchema = z.object({
 
 // フィルターオプションのバリデーションスキーマ
 export const filterOptionsSchema = z.object({
-  searchTerm: z.string().default(""),
-  quoteCoin: z.string().default(""),
-  favoritesOnly: z.boolean().default(false)
+  search: z.string().default(""),
+  quoteAsset: z.string().default(""),
+  showFavoritesOnly: z.boolean().default(false)
 })
 
 // シンボルセレクターのプロパティのバリデーションスキーマ

--- a/services/symbol/symbol-service.ts
+++ b/services/symbol/symbol-service.ts
@@ -101,8 +101,8 @@ class SymbolService {
     let filtered = [...symbols];
 
     // 検索語でフィルター
-    if (options.searchTerm) {
-      const term = options.searchTerm.toLowerCase();
+    if (options.search) {
+      const term = options.search.toLowerCase();
       filtered = filtered.filter(
         (s) =>
           s.symbol.toLowerCase().includes(term) ||
@@ -112,12 +112,12 @@ class SymbolService {
     }
 
     // 基軸通貨でフィルター
-    if (options.quoteCoin) {
-      filtered = filtered.filter((s) => s.quoteCoin === options.quoteCoin);
+    if (options.quoteAsset) {
+      filtered = filtered.filter((s) => s.quoteCoin === options.quoteAsset);
     }
 
     // お気に入りでフィルター
-    if (options.favoritesOnly) {
+    if (options.showFavoritesOnly) {
       filtered = filtered.filter((s) => s.favorite);
     }
 

--- a/types/validations/symbol.ts
+++ b/types/validations/symbol.ts
@@ -19,9 +19,9 @@ export const symbolInfoSchema = z.object({
 
 // フィルターオプションのバリデーションスキーマ
 export const filterOptionsSchema = z.object({
-  searchTerm: z.string().default(""),
-  quoteCoin: z.string().default(""),
-  favoritesOnly: z.boolean().default(false)
+  search: z.string().default(""),
+  quoteAsset: z.string().default(""),
+  showFavoritesOnly: z.boolean().default(false)
 })
 
 // シンボルセレクターのプロパティのバリデーションスキーマ


### PR DESCRIPTION
## Summary
- update tests to use new filter option names
- update validation schemas to match new `search`, `quoteAsset`, and `showFavoritesOnly` options
- adapt symbol service filtering logic for new option names

## Testing
- `npm test` *(fails: Cannot find module 'zustand', ...)*