### PR TITLE
Fix symbol selector

### DIFF
--- a/store/symbol/selectors.ts
+++ b/store/symbol/selectors.ts
@@ -19,7 +19,16 @@ import type { SymbolSliceState } from './state';
 /**
  * シンボルスライス全体を取得する基本セレクター
  */
-export const selectSymbolState = (state: RootState): SymbolSliceState => state as SymbolSliceState;
+export const selectSymbolState = (state: RootState): SymbolSliceState => ({
+  currentSymbol: state.currentSymbol,
+  exchangeType: state.exchangeProductType,
+  symbolsList: state.symbolsList,
+  filteredSymbols: state.filteredSymbols,
+  filterOptions: state.filterOptions,
+  isLoading: state.isLoading,
+  error: state.error,
+  changeHistory: state.changeHistory
+});
 
 /**
  * 現在のシンボルを選択するセレクター


### PR DESCRIPTION
## Summary
- implement `selectSymbolState` to return a SymbolSliceState object from root state

## Testing
- `npm test` *(fails: Cannot find module 'zustand' or its corresponding type declarations)*