### PR TITLE
Fix path imports to use aliases

### DIFF
--- a/__tests__/api/chart-data-service.test.ts
+++ b/__tests__/api/chart-data-service.test.ts
@@ -7,7 +7,7 @@
  * 更新: 2025-10-09: S-10.2フェーズ: ExchangeType型の一貫性を確保
  */
 
-import { OHLCData, OrderBookData } from '../../types/chart';
+import { OHLCData, OrderBookData } from '@/types/chart';
 import { type ExchangeType } from '@/types/constants/enums';
 
 // テスト用のExchangeType定数

--- a/__tests__/chart/dataSanitizer.test.ts
+++ b/__tests__/chart/dataSanitizer.test.ts
@@ -15,7 +15,7 @@ import {
   generateDefaultChartData
 } from '../../utils/chart/sanitizers';
 
-import { OHLCData } from '../../types/chart';
+import { OHLCData } from '@/types/chart';
 import { jest } from '@jest/globals';
 
 // loggerをモック

--- a/__tests__/data/order-book-service.test.ts
+++ b/__tests__/data/order-book-service.test.ts
@@ -8,7 +8,7 @@
 import { orderBookService } from '../../services/data/order-book-service';
 import { BitgetApiClient } from '../../services/api/bitget/client.new';
 import { getSocketService } from '../../services/socket/service';
-import { OrderBookData } from '../../types/chart';
+import { OrderBookData } from '@/types/chart';
 
 // ブラウザ環境のモック
 Object.defineProperty(global, 'window', {

--- a/services/api/chart-data-service.ts
+++ b/services/api/chart-data-service.ts
@@ -11,7 +11,7 @@
 
 import { EventEmitter } from 'events';
 import { ExchangeType } from '@/types/api';
-import { OHLCData, OrderBookData, Timeframe } from '../../types/chart';
+import { OHLCData, OrderBookData, Timeframe } from '@/types/chart';
 import { IChartDataService } from './interfaces';
 import { dataSourceFactory } from './data-source-factory';
 import { logger } from '../../utils/logger';

--- a/services/api/interfaces.ts
+++ b/services/api/interfaces.ts
@@ -9,8 +9,8 @@
  * 単一責任の原則（SRP）に基づき、各インターフェースは明確に分離された責任を持ちます。
  */
 
-import { ExchangeType, ProductType } from '../../types/exchange';
-import { OHLCData, OrderBookData, Timeframe } from '../../types/chart';
+import { ExchangeType, ProductType } from '@/types/exchange';
+import { OHLCData, OrderBookData, Timeframe } from '@/types/chart';
 
 /**
  * WebSocketクライアントインターフェース

--- a/services/data/chart-data-service.ts
+++ b/services/data/chart-data-service.ts
@@ -9,7 +9,7 @@
 import { EventEmitter } from 'events';
 import { BitgetApiClient } from '../api/bitget/client.new';
 import { IChartDataService } from './interfaces';
-import { OHLCData, Timeframe } from '../../types/chart';
+import { OHLCData, Timeframe } from '@/types/chart';
 import { ExchangeType, ProductType } from '@/types/api';
 import { useRootStore } from '../../store/rootStore';
 import { logger } from '../../utils/logger';

--- a/services/data/dataFetchService.ts
+++ b/services/data/dataFetchService.ts
@@ -16,7 +16,7 @@
 import { EventEmitter } from 'events';
 import { BitgetApiClient } from '../api/bitget/client.new';
 import { IDataFetchService } from './dataFetchTypes';
-import { OHLCData, Timeframe } from '../../types/chart';
+import { OHLCData, Timeframe } from '@/types/chart';
 import { ExchangeType, ProductType } from '@/types/api';
 import { useRootStore } from '../../store/rootStore';
 import { toExchangeType } from '@/utils/exchangeTypeUtils';

--- a/services/data/dataFetchTypes.ts
+++ b/services/data/dataFetchTypes.ts
@@ -6,7 +6,7 @@
  */
 
 import { ExchangeType, ProductType } from '@/types/api';
-import { OHLCData, Timeframe } from '../../types/chart';
+import { OHLCData, Timeframe } from '@/types/chart';
 
 export interface IDataFetchService {
   // オーダーブック関連のメソッドはIOrderBookServiceに移行しました

--- a/services/data/interfaces.ts
+++ b/services/data/interfaces.ts
@@ -7,7 +7,7 @@
  */
 
 import { ExchangeType, ProductType } from '@/types/api';
-import { OHLCData, Timeframe, OrderBookData } from '../../types/chart';
+import { OHLCData, Timeframe, OrderBookData } from '@/types/chart';
 
 /**
  * オーダーブックサービスのインターフェース

--- a/services/data/order-book-service.ts
+++ b/services/data/order-book-service.ts
@@ -9,7 +9,7 @@
 import { EventEmitter } from 'events';
 import { BitgetApiClient } from '../api/bitget/client.new';
 import { IOrderBookService } from '../api/interfaces';
-import { OrderBookData } from '../../types/chart';
+import { OrderBookData } from '@/types/chart';
 import { ExchangeType } from '@/types/api';
 import { logger } from '../../utils/logger';
 import { normalizeSymbol } from '../../utils/formatters';

--- a/services/socket/interfaces.ts
+++ b/services/socket/interfaces.ts
@@ -7,8 +7,8 @@
  */
 
 import { Socket } from 'socket.io-client';
-import { OrderBookData } from '../../types/market';
-import { OHLCData, Timeframe } from '../../types/chart';
+import { OrderBookData } from '@/types/market';
+import { OHLCData, Timeframe } from '@/types/chart';
 import { ProductType } from '@/types/api';
 
 /**

--- a/services/socket/mock-service.ts
+++ b/services/socket/mock-service.ts
@@ -8,7 +8,7 @@
 
 import { EventEmitter } from 'events';
 import { OrderBookData, OrderBookEntry } from '@/types/common/orderbook';
-import { OHLCData, Timeframe } from '../../types/chart';
+import { OHLCData, Timeframe } from '@/types/chart';
 import { ProductType } from '@/types/api';
 import { logger } from '../../utils/logger';
 import { ISocketService } from './interfaces';

--- a/services/socket/service.ts
+++ b/services/socket/service.ts
@@ -5,8 +5,8 @@
 
 import { EventEmitter } from 'events';
 import { Socket } from 'socket.io-client';
-import { OrderBookData } from '../../types/market';
-import { OHLCData, Timeframe } from '../../types/chart';
+import { OrderBookData } from '@/types/market';
+import { OHLCData, Timeframe } from '@/types/chart';
 import { ProductType } from '@/types/api';
 import { logger } from '../../utils/logger';
 import { ISocketService } from './interfaces';

--- a/services/socket/socket-service.ts
+++ b/services/socket/socket-service.ts
@@ -7,8 +7,8 @@
  */
 
 import { Socket } from 'socket.io-client';
-import { OrderBookData } from '../../types/market';
-import { OHLCData, Timeframe } from '../../types/chart';
+import { OrderBookData } from '@/types/market';
+import { OHLCData, Timeframe } from '@/types/chart';
 import { ProductType } from '@/types/api';
 import { BitgetApiClient } from '../api/bitget/client.new';
 import { logger } from '../../utils/logger';

--- a/services/socket/subscription-manager.ts
+++ b/services/socket/subscription-manager.ts
@@ -7,8 +7,8 @@
  */
 
 import { Socket } from 'socket.io-client';
-import { OrderBookData } from '../../types/market';
-import { OHLCData, Timeframe } from '../../types/chart';
+import { OrderBookData } from '@/types/market';
+import { OHLCData, Timeframe } from '@/types/chart';
 import { ProductType } from '@/types/api';
 import { normalizeSymbol } from '../../lib/utils';
 import { logger } from '../../utils/logger';

--- a/src/mastra/tools/chart-capture.ts
+++ b/src/mastra/tools/chart-capture.ts
@@ -4,7 +4,7 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { v4 as uuidv4 } from "uuid";
-import { analyzeChartWithAI } from "../../../utils/aiUtils";
+import { analyzeChartWithAI } from "@/utils/aiUtils";
 
 // グローバル関数の型定義
 declare global {

--- a/src/mastra/tools/instrument-type-tools.ts
+++ b/src/mastra/tools/instrument-type-tools.ts
@@ -4,7 +4,7 @@
 
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
-import { logger } from "../../../utils/common";
+import { logger } from "@/utils/common";
 import fetch, { Response } from "node-fetch";
 // 取引タイプを表す型（現物/先物）
 type TradeType = 'spot' | 'futures';

--- a/src/mastra/tools/symbol-tools.ts
+++ b/src/mastra/tools/symbol-tools.ts
@@ -7,7 +7,7 @@
 
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
-import { logger } from "../../../utils/common";
+import { logger } from "@/utils/common";
 import fetch from "node-fetch";
 import { ExchangeType } from "../../../types/api";
 

--- a/src/mastra/tools/timeframe-tools.ts
+++ b/src/mastra/tools/timeframe-tools.ts
@@ -4,7 +4,7 @@
 
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
-import { logger } from "../../../utils/common";
+import { logger } from "@/utils/common";
 import fetch from "node-fetch";
 
 /**

--- a/src/mastra/workflows/chart-analysis.ts
+++ b/src/mastra/workflows/chart-analysis.ts
@@ -4,7 +4,7 @@
 import { z } from "zod";
 import { chartCaptureAnalysisTool } from "../tools/chart-capture";
 import { changeTimeframeTool } from "../tools/timeframe-tools";
-import { logger } from "../../../utils/common";
+import { logger } from "@/utils/common";
 
 // 入力パラメータの型定義
 export interface TimeframeAnalysisParams {

--- a/src/mastra/workflows/entry-suggestion.ts
+++ b/src/mastra/workflows/entry-suggestion.ts
@@ -3,7 +3,7 @@
 
 import { entrySuggestionTool } from "../tools/entry-suggestion";
 import { multiTimeframeAnalysisWorkflow, MultiTimeframeAnalysisParams } from "./timeframe-analysis";
-import { logger } from "../../../utils/common";
+import { logger } from "@/utils/common";
 import { TradeSide } from "@/types/entry";
 
 // 入力パラメータの型定義

--- a/src/mastra/workflows/timeframe-analysis.ts
+++ b/src/mastra/workflows/timeframe-analysis.ts
@@ -2,7 +2,7 @@
 // 更新: 複数時間足分析ワークフローを型安全で堅牢な実装に変更
 
 import { multiTimeframeAnalysisTool } from "../tools/multi-timeframe-tools";
-import { logger } from "../../../utils/common";
+import { logger } from "@/utils/common";
 
 // 入力パラメータの型定義
 export interface MultiTimeframeAnalysisParams {

--- a/store/chat/actions.ts
+++ b/store/chat/actions.ts
@@ -13,9 +13,9 @@
 
 // 循環参照を避けるため、直接インポートせずに動的にインポートする
 // import { useRootStore } from '../rootStore'
-import type { ExtendedMessage, ProposalType } from '../../types/chat/base'
+import type { ExtendedMessage, ProposalType } from '@/types/chat'
 import type { ChatSliceState, ConversationState, ConnectionStatus } from './state'
-import { logger } from '../../utils/common'
+import { logger } from '@/utils/common'
 import { subscribeToConversationMessages } from '../../lib/supabase/features/conversations'
 import { useToast } from '../../components/ui/use-toast'
 import { createEmptyConversation } from './utils'

--- a/store/chat/state.ts
+++ b/store/chat/state.ts
@@ -6,7 +6,7 @@
 // 更新: 2025/6/30 - インポートパスを修正（/types/chat → /types/chat/base）
 // 更新: 2025/6/30 - インポートパスを相対パスに変更
 
-import type { ExtendedMessage } from '../../types/chat/base'
+import type { ExtendedMessage } from '@/types/chat'
 
 // リアルタイム接続状態タイプ
 export type ConnectionStatus = 

--- a/store/chat/utils.ts
+++ b/store/chat/utils.ts
@@ -3,7 +3,7 @@
 // 作成: 2025/6/30 - ConversationState初期化の一貫性を確保するためのヘルパー関数
 
 import type { ConversationState, ConnectionStatus } from './state';
-import type { ExtendedMessage } from '../../types/chat/base';
+import type { ExtendedMessage } from '@/types/chat';
 
 /**
  * 空の会話状態を作成するヘルパー関数


### PR DESCRIPTION
## Summary
- use `@/utils` in mastra tools/workflows
- adjust chat store imports
- migrate `../../types/*` imports to `@/types/*`

## Testing
- `npm run lint` *(fails: Failed to load native binding)*