### PR TITLE
Add Jest types to tsconfig.test.json

### DIFF
--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -4,6 +4,10 @@
     "typeRoots": [
       "./node_modules/@types"
     ],
+    "types": [
+      "jest",
+      "node"
+    ],
     "allowJs": true,
     "noEmit": true,
     "module": "esnext",


### PR DESCRIPTION
## Summary
- include Jest types in tsconfig.test.json for `@jest/globals`

## Testing
- `pnpm typecheck:test` *(fails: Cannot find module '@/utils/logger' and other type errors)*